### PR TITLE
Adding support for environment globals

### DIFF
--- a/examples/complete/fixtures.tfvars
+++ b/examples/complete/fixtures.tfvars
@@ -3,3 +3,5 @@ stack_config_path = "stacks"
 branch = "master"
 
 repository = "spacelift-demo"
+
+manage_state = true

--- a/examples/complete/stacks/ue2-globals.yaml
+++ b/examples/complete/stacks/ue2-globals.yaml
@@ -1,2 +1,2 @@
-environment: "ue2" 
+environment: "ue2"
 another_env_var: "it works!"

--- a/examples/complete/stacks/ue2-globals.yaml
+++ b/examples/complete/stacks/ue2-globals.yaml
@@ -1,0 +1,2 @@
+environment: "ue2" 
+another_env_var: "it works!"

--- a/examples/complete/stacks/ue2-testing.yaml
+++ b/examples/complete/stacks/ue2-testing.yaml
@@ -1,7 +1,6 @@
 components:
   globals:
     stage: testing
-    environment: ue2
 
   terraform:
     example2:

--- a/examples/complete/stacks/uw2-globals.yaml
+++ b/examples/complete/stacks/uw2-globals.yaml
@@ -1,0 +1,2 @@
+environment: "uw2" 
+another_env_var: "it works again!"

--- a/examples/complete/stacks/uw2-globals.yaml
+++ b/examples/complete/stacks/uw2-globals.yaml
@@ -1,2 +1,2 @@
-environment: "uw2" 
+environment: "uw2"
 another_env_var: "it works again!"

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,10 @@ locals {
   // Result ex: [gbl-audit, gbl-auto, gbl-dev, ...]
   config_files = { for f in local.config_filenames : trimsuffix(basename(f), ".yaml") => try(yamldecode(file("${local.stack_config_path}/${f}")), {}) }
   // Result ex: { gbl-audit = { globals = { ... }, terraform = { component1 = { vars = ... }, component2 = { vars = ... } } } }
-  components = { for f in keys(local.config_files) : f => lookup(local.config_files[f], "components", {}) if (replace(f, "globals", "") == f) }
+  components = { for f in keys(local.config_files) : f => lookup(local.config_files[f], "components", {}) if(replace(f, "globals", "") == f) }
 
   // Parse our environment global variables
-  environment_globals = { for k,v in local.config_files : trimsuffix(k, "-globals") => v if (replace(k, "-globals", "") != k) }
+  environment_globals = { for k, v in local.config_files : trimsuffix(k, "-globals") => v if(replace(k, "-globals", "") != k) }
 
   // Pull our universal globals that will be attached to ALL stacks
   globals = try(local.config_files["globals"], {})

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
 
   // Parse our environment global variables
   environment_globals = { for k,v in local.config_files : trimsuffix(k, "-globals") => v if (replace(k, "-globals", "") != k) }
-  
+
   // Pull our universal globals that will be attached to ALL stacks
   globals = try(local.config_files["globals"], {})
 }

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,12 @@ locals {
   // Result ex: [gbl-audit, gbl-auto, gbl-dev, ...]
   config_files = { for f in local.config_filenames : trimsuffix(basename(f), ".yaml") => try(yamldecode(file("${local.stack_config_path}/${f}")), {}) }
   // Result ex: { gbl-audit = { globals = { ... }, terraform = { component1 = { vars = ... }, component2 = { vars = ... } } } }
-  components = { for f in keys(local.config_files) : f => lookup(local.config_files[f], "components", {}) if f != "globals" }
+  components = { for f in keys(local.config_files) : f => lookup(local.config_files[f], "components", {}) if (replace(f, "globals", "") == f) }
 
+  // Parse our environment global variables
+  environment_globals = { for k,v in local.config_files : trimsuffix(k, "-globals") => v if (replace(k, "-globals", "") != k) }
+  
+  // Pull our universal globals that will be attached to ALL stacks
   globals = try(local.config_files["globals"], {})
 }
 
@@ -29,7 +33,7 @@ module "spacelift_environment" {
   trigger_policy_id  = spacelift_policy.trigger_global.id
   push_policy_id     = spacelift_policy.push.id
   stack_config_name  = each.key
-  environment_values = each.value.globals
+  environment_values = merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {}))
   components         = local.components[each.key].terraform
   components_path    = var.components_path
   repository         = var.repository

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -24,7 +24,7 @@ module "component_context" {
 }
 
 resource "spacelift_context_attachment" "global" {
-  count = var.enabled && (var.global_context_id != null) ? 1 : 0
+  count = var.enabled ? 1 : 0
 
   context_id = var.global_context_id
   stack_id   = spacelift_stack.default[0].id


### PR DESCRIPTION
## what
* Explicitly setting `manage_state` in `complete` example since it now defaults to `false` and we need it to be `true`
* Adding support for environment globals YAML configurations
* Adding `<environment>-globals.yaml` configuration yamls to `complete` example
* Reverting change to global context attachment in stack module due to Terraform `count` error (since the variable is dependency on resource creation)

**NOTE:** Some of the new environment global variable logic is a little rough around the edges. The approach was to get this working quickly, with the expectation that we'll be replacing the YAML config parsing w/ our upcoming YAML config module in the near future.

Also, these changes have been tested in Spacelift!


