### PR TITLE
Update rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| autodeploy | Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration) | `bool` | `false` | no |
 | branch | Specify which branch to use within your infrastructure repo | `string` | `"main"` | no |
 | components\_path | The relative pathname for where all components reside | `string` | `"components"` | no |
 | external\_execution | Set this to true if you're calling this module from outside of a Spacelift stack (e.g. the `complete` example). | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -187,8 +187,11 @@ Available targets:
 | external\_execution | Set this to true if you're calling this module from outside of a Spacelift stack (e.g. the `complete` example). | `bool` | `false` | no |
 | manage\_state | Global flag to enable/disable manage\_state settings for all project stacks. | `bool` | `true` | no |
 | repository | The name of your infrastructure repo | `string` | n/a | yes |
+| runner\_image | The full image name and tag of the Docker image to use in Spacelift | `string` | `null` | no |
 | stack\_config\_path | Relative path to YAML config files | `string` | `null` | no |
 | stack\_config\_pattern | File pattern used to locate configuration files | `string` | `"*.yaml"` | no |
+| terraform\_version | Specify the version of Terraform to use for the stack | `string` | `null` | no |
+| worker\_pool\_id | The immutable ID (slug) of the worker pool | `string` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,15 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
-**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
-Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/releases).
+**IMPORTANT:** We do not pin modules to versions in our examples because of the
+difficulty of keeping the versions in the documentation in sync with the latest released versions.
+We highly recommend that in your code you pin the version to the exact version you are
+using so that your infrastructure remains stable, and update versions in a
+systematic way so that they do not catch you by surprise.
+
+Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
+the registry shows many of our inputs as required when in fact they are optional.
+The table below correctly indicates which inputs are required.
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,6 +16,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| autodeploy | Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration) | `bool` | `false` | no |
 | branch | Specify which branch to use within your infrastructure repo | `string` | `"main"` | no |
 | components\_path | The relative pathname for where all components reside | `string` | `"components"` | no |
 | external\_execution | Set this to true if you're calling this module from outside of a Spacelift stack (e.g. the `complete` example). | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,8 +21,11 @@
 | external\_execution | Set this to true if you're calling this module from outside of a Spacelift stack (e.g. the `complete` example). | `bool` | `false` | no |
 | manage\_state | Global flag to enable/disable manage\_state settings for all project stacks. | `bool` | `true` | no |
 | repository | The name of your infrastructure repo | `string` | n/a | yes |
+| runner\_image | The full image name and tag of the Docker image to use in Spacelift | `string` | `null` | no |
 | stack\_config\_path | Relative path to YAML config files | `string` | `null` | no |
 | stack\_config\_pattern | File pattern used to locate configuration files | `string` | `"*.yaml"` | no |
+| terraform\_version | Specify the version of Terraform to use for the stack | `string` | `null` | no |
+| worker\_pool\_id | The immutable ID (slug) of the worker pool | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,7 @@ module "spacelift_environment" {
   trigger_policy_id  = spacelift_policy.trigger_global.id
   push_policy_id     = spacelift_policy.push.id
   stack_config_name  = each.key
-  environment_values = { for k,v in merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {})) : k => jsonencode(v) }
-  #environment_values = merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {}))
+  environment_values = { for k, v in merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {})) : k => jsonencode(v) }
   components         = local.components[each.key].terraform
   components_path    = var.components_path
   repository         = var.repository
@@ -42,7 +41,6 @@ module "spacelift_environment" {
   manage_state       = var.manage_state
   worker_pool_id     = var.worker_pool_id
   runner_image       = var.runner_image
-  before_init        = var.before_init
   terraform_version  = var.terraform_version
 }
 

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,8 @@ module "spacelift_environment" {
   trigger_policy_id  = spacelift_policy.trigger_global.id
   push_policy_id     = spacelift_policy.push.id
   stack_config_name  = each.key
-  environment_values = { for k,v in merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {})) : k => jsonencode(v) }
+  #environment_values = { for k,v in merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {})) : k => jsonencode(v) }
+  environment_values = merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {}))
   components         = local.components[each.key].terraform
   components_path    = var.components_path
   repository         = var.repository

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ module "spacelift_environment" {
   trigger_policy_id  = spacelift_policy.trigger_global.id
   push_policy_id     = spacelift_policy.push.id
   stack_config_name  = each.key
-  environment_values = merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {}))
+  environment_values = { for k,v in merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {})) : k => jsonencode(v) }
   components         = local.components[each.key].terraform
   components_path    = var.components_path
   repository         = var.repository

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,6 @@ module "spacelift_environment" {
   manage_state       = var.manage_state
   worker_pool_id     = var.worker_pool_id
   runner_image       = var.runner_image
-  role_arn           = var.role_arn
   before_init        = var.before_init
 }
 

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   // Result ex: [gbl-audit, gbl-auto, gbl-dev, ...]
   config_files = { for f in local.config_filenames : trimsuffix(basename(f), ".yaml") => try(yamldecode(file("${local.stack_config_path}/${f}")), {}) }
   // Result ex: { gbl-audit = { globals = { ... }, terraform = { component1 = { vars = ... }, component2 = { vars = ... } } } }
-  components = { for f in keys(local.config_files) : f => lookup(local.config_files[f], "projects", {}) if(replace(f, "globals", "") == f) }
+  components = { for f in keys(local.config_files) : f => lookup(local.config_files[f], "components", {}) if(replace(f, "globals", "") == f) }
 
   // Parse our environment global variables
   environment_globals = { for k, v in local.config_files : trimsuffix(k, "-globals") => v if(replace(k, "-globals", "") != k) }

--- a/main.tf
+++ b/main.tf
@@ -71,14 +71,14 @@ resource "spacelift_policy" "push" {
 }
 
 
-# data "spacelift_current_stack" "this" {
-#   count = var.external_execution ? 0 : 1
-# }
+data "spacelift_current_stack" "this" {
+  count = var.external_execution ? 0 : 1
+}
 
-# # Attach the Environment Trigger Policy to the current stack
-# resource "spacelift_policy_attachment" "trigger_global" {
-#   count = var.external_execution ? 0 : 1
+# Attach the Environment Trigger Policy to the current stack
+resource "spacelift_policy_attachment" "trigger_global" {
+  count = var.external_execution ? 0 : 1
 
-#   policy_id = spacelift_policy.trigger_global.id
-#   stack_id  = data.spacelift_current_stack.this[0].id
-# }
+  policy_id = spacelift_policy.trigger_global.id
+  stack_id  = data.spacelift_current_stack.this[0].id
+}

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ module "spacelift_environment" {
   worker_pool_id     = var.worker_pool_id
   runner_image       = var.runner_image
   before_init        = var.before_init
+  terraform_version  = var.terraform_version
 }
 
 # Define the global trigger policy that allows us to trigger on various context-level updates

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
 module "global_context" {
   source = "./modules/context"
 
-  enabled = length(local.globals) > 0 ? true : false
+  enabled = true
 
   context_name          = "global"
   environment_variables = local.globals
@@ -42,6 +42,7 @@ module "spacelift_environment" {
   worker_pool_id     = var.worker_pool_id
   runner_image       = var.runner_image
   terraform_version  = var.terraform_version
+  autodeploy         = var.autodeploy
 }
 
 # Define the global trigger policy that allows us to trigger on various context-level updates
@@ -67,7 +68,6 @@ resource "spacelift_policy" "push" {
   name = "Component Push Policy"
   body = file("${path.module}/policies/push-stack.rego")
 }
-
 
 data "spacelift_current_stack" "this" {
   count = var.external_execution ? 0 : 1

--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,8 @@ module "spacelift_environment" {
   trigger_policy_id  = spacelift_policy.trigger_global.id
   push_policy_id     = spacelift_policy.push.id
   stack_config_name  = each.key
-  #environment_values = { for k,v in merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {})) : k => jsonencode(v) }
-  environment_values = merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {}))
+  environment_values = { for k,v in merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {})) : k => jsonencode(v) }
+  #environment_values = merge(each.value.globals, lookup(local.environment_globals, split("-", each.key)[0], {}))
   components         = local.components[each.key].terraform
   components_path    = var.components_path
   repository         = var.repository
@@ -71,14 +71,14 @@ resource "spacelift_policy" "push" {
 }
 
 
-data "spacelift_current_stack" "this" {
-  count = var.external_execution ? 0 : 1
-}
+# data "spacelift_current_stack" "this" {
+#   count = var.external_execution ? 0 : 1
+# }
 
-# Attach the Environment Trigger Policy to the current stack
-resource "spacelift_policy_attachment" "trigger_global" {
-  count = var.external_execution ? 0 : 1
+# # Attach the Environment Trigger Policy to the current stack
+# resource "spacelift_policy_attachment" "trigger_global" {
+#   count = var.external_execution ? 0 : 1
 
-  policy_id = spacelift_policy.trigger_global.id
-  stack_id  = data.spacelift_current_stack.this[0].id
-}
+#   policy_id = spacelift_policy.trigger_global.id
+#   stack_id  = data.spacelift_current_stack.this[0].id
+# }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   // Result ex: [gbl-audit, gbl-auto, gbl-dev, ...]
   config_files = { for f in local.config_filenames : trimsuffix(basename(f), ".yaml") => try(yamldecode(file("${local.stack_config_path}/${f}")), {}) }
   // Result ex: { gbl-audit = { globals = { ... }, terraform = { component1 = { vars = ... }, component2 = { vars = ... } } } }
-  components = { for f in keys(local.config_files) : f => lookup(local.config_files[f], "components", {}) if(replace(f, "globals", "") == f) }
+  components = { for f in keys(local.config_files) : f => lookup(local.config_files[f], "projects", {}) if(replace(f, "globals", "") == f) }
 
   // Parse our environment global variables
   environment_globals = { for k, v in local.config_files : trimsuffix(k, "-globals") => v if(replace(k, "-globals", "") != k) }

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,10 @@ module "spacelift_environment" {
   repository         = var.repository
   branch             = var.branch
   manage_state       = var.manage_state
+  worker_pool_id     = var.worker_pool_id
+  runner_image       = var.runner_image
+  role_arn           = var.role_arn
+  before_init        = var.before_init
 }
 
 # Define the global trigger policy that allows us to trigger on various context-level updates

--- a/modules/context/main.tf
+++ b/modules/context/main.tf
@@ -9,6 +9,6 @@ resource "spacelift_environment_variable" "default" {
 
   context_id = spacelift_context.default[0].id
   name       = "TF_VAR_${each.key}"
-  value      = each.value
+  value      = trim(each.value, "\"")
   write_only = false
 }

--- a/modules/context/variables.tf
+++ b/modules/context/variables.tf
@@ -10,6 +10,6 @@ variable "context_name" {
 }
 
 variable "environment_variables" {
-  type        = map
+  type        = map(any)
   description = "A map of environment variables to add to the context"
 }

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -22,11 +22,10 @@ module "components" {
   repository            = var.repository
   branch                = var.branch
   manage_state          = var.manage_state
-  environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
+  environment_variables = { for k, v in each.value.vars : k => jsonencode(v) }
   terraform_version     = coalesce(try(each.value.terraform_version, null), var.terraform_version)
   worker_pool_id        = var.worker_pool_id
   runner_image          = try(var.runner_image, null)
-  before_init           = try(var.before_init, null)
   triggers              = coalesce(try(each.value.triggers, null), [])
   trigger_policy_id     = var.trigger_policy_id
   push_policy_id        = var.push_policy_id

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -14,7 +14,7 @@ module "components" {
     for k, v in var.components : "${var.stack_config_name}-${k}" => merge({ "component" : k }, v)
   }
 
-  enabled               = try(each.value.workspace_enabled, false)
+  enabled               = try(each.value.workspace_enabled, true)
   stack_name            = "${var.stack_config_name}-${each.value.component}"
   environment_name      = var.stack_config_name
   autodeploy            = try(each.value.autodeploy, true)

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -25,6 +25,7 @@ module "components" {
   environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
   terraform_version     = try(each.value.terraform_version, null)
   worker_pool_id        = try(each.value.worker_pool_id, null)
+  runner_image          = try(each.value.runner_image, null)
   triggers              = coalesce(try(each.value.triggers, null), [])
   trigger_policy_id     = var.trigger_policy_id
   push_policy_id        = var.push_policy_id

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -24,7 +24,7 @@ module "components" {
   manage_state          = var.manage_state
   environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
   terraform_version     = var.terraform_version
-  worker_pool_id        = try(each.value.worker_pool_id, null)
+  worker_pool_id        = var.worker_pool_id
   runner_image          = try(var.runner_image, null)
   before_init           = try(var.before_init, null)
   triggers              = coalesce(try(each.value.triggers, null), [])

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -25,7 +25,8 @@ module "components" {
   environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
   terraform_version     = try(each.value.terraform_version, null)
   worker_pool_id        = try(each.value.worker_pool_id, null)
-  runner_image          = try(var.environment_values.runner_image, null)
+  runner_image          = try(var.runner_image, null)
+  before_init           = try(var.before_init, null)
   triggers              = coalesce(try(each.value.triggers, null), [])
   trigger_policy_id     = var.trigger_policy_id
   push_policy_id        = var.push_policy_id

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -17,7 +17,7 @@ module "components" {
   enabled               = try(each.value.workspace_enabled, true)
   stack_name            = "${var.stack_config_name}-${each.value.component}"
   environment_name      = var.stack_config_name
-  autodeploy            = try(each.value.autodeploy, false)
+  autodeploy            = coalesce(try(each.value.autodeploy, null), var.autodeploy)
   component_root        = format("%s/%s", var.components_path, try(each.value.custom_component_folder, each.value.component))
   repository            = var.repository
   branch                = var.branch

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -23,7 +23,7 @@ module "components" {
   branch                = var.branch
   manage_state          = var.manage_state
   environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
-  terraform_version     = var.terraform_version
+  terraform_version     = coalesce(each.value.terraform_version, var.terraform_version)
   worker_pool_id        = var.worker_pool_id
   runner_image          = try(var.runner_image, null)
   before_init           = try(var.before_init, null)

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -17,7 +17,7 @@ module "components" {
   enabled               = try(each.value.workspace_enabled, true)
   stack_name            = "${var.stack_config_name}-${each.value.component}"
   environment_name      = var.stack_config_name
-  autodeploy            = try(each.value.autodeploy, true)
+  autodeploy            = try(each.value.autodeploy, false)
   component_root        = format("%s/%s", var.components_path, try(each.value.custom_component_folder, each.value.component))
   repository            = var.repository
   branch                = var.branch

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -23,7 +23,7 @@ module "components" {
   branch                = var.branch
   manage_state          = var.manage_state
   environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
-  terraform_version     = coalesce(each.value.terraform_version, var.terraform_version)
+  terraform_version     = coalesce(try(each.value.terraform_version, null), var.terraform_version)
   worker_pool_id        = var.worker_pool_id
   runner_image          = try(var.runner_image, null)
   before_init           = try(var.before_init, null)

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -25,7 +25,7 @@ module "components" {
   environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
   terraform_version     = try(each.value.terraform_version, null)
   worker_pool_id        = try(each.value.worker_pool_id, null)
-  runner_image          = try(each.value.runner_image, null)
+  runner_image          = try(var.environment_values.runner_image, null)
   triggers              = coalesce(try(each.value.triggers, null), [])
   trigger_policy_id     = var.trigger_policy_id
   push_policy_id        = var.push_policy_id

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -22,7 +22,7 @@ module "components" {
   repository            = var.repository
   branch                = var.branch
   manage_state          = var.manage_state
-  environment_variables = each.value.vars
+  environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
   terraform_version     = try(each.value.terraform_version, null)
   worker_pool_id        = try(each.value.worker_pool_id, null)
   triggers              = coalesce(try(each.value.triggers, null), [])

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -23,7 +23,7 @@ module "components" {
   branch                = var.branch
   manage_state          = var.manage_state
   environment_variables = { for k,v in each.value.vars : k => jsonencode(v) }
-  terraform_version     = try(each.value.terraform_version, null)
+  terraform_version     = var.terraform_version
   worker_pool_id        = try(each.value.worker_pool_id, null)
   runner_image          = try(var.runner_image, null)
   before_init           = try(var.before_init, null)

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -24,6 +24,7 @@ module "components" {
   manage_state          = var.manage_state
   environment_variables = each.value.vars
   terraform_version     = try(each.value.terraform_version, null)
+  worker_pool_id        = try(each.value.worker_pool_id, null)
   triggers              = coalesce(try(each.value.triggers, null), [])
   trigger_policy_id     = var.trigger_policy_id
   push_policy_id        = var.push_policy_id

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -62,6 +62,12 @@ variable "manage_state" {
   default     = true
 }
 
+variable "terraform_version" {
+  type        = string
+  description = "Specify the version of Terraform to use for the stack"
+  default     = null
+}
+
 variable "worker_pool_id" {
   type        = string
   description = "The immutable ID (slug) of the worker pool"

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -79,9 +79,3 @@ variable "runner_image" {
   description = "The full image name and tag of the Docker image to use in Spacelift"
   default     = null
 }
-
-variable "before_init" {
-  type        = list
-  description = "A list of commands to execute in Spacelift before initializing Terraform"
-  default     = null
-}

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -28,7 +28,7 @@ variable "push_policy_id" {
 }
 
 variable "environment_values" {
-  type        = map
+  type        = map(any)
   default     = {}
   description = "The global values applied to all workspaces within the environment."
 }

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -79,3 +79,9 @@ variable "runner_image" {
   description = "The full image name and tag of the Docker image to use in Spacelift"
   default     = null
 }
+
+variable "autodeploy" {
+  type        = string
+  description = "Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration)"
+  default     = null
+}

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -61,3 +61,27 @@ variable "manage_state" {
   description = "Global flag to enable/disable manage_state settings in all stacks."
   default     = true
 }
+
+variable "worker_pool_id" {
+  type        = string
+  description = "The immutable ID (slug) of the worker pool"
+  default     = null
+}
+
+variable "role_arn" {
+  type        = string
+  description = "The role_arn to use for Spacelift executions"
+  default     = null
+}
+
+variable "runner_image" {
+  type        = string
+  description = "The full image name and tag of the Docker image to use in Spacelift"
+  default     = null
+}
+
+variable "before_init" {
+  type        = list
+  description = "A list of commands to execute in Spacelift before initializing Terraform"
+  default     = null
+}

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -68,12 +68,6 @@ variable "worker_pool_id" {
   default     = null
 }
 
-variable "role_arn" {
-  type        = string
-  description = "The role_arn to use for Spacelift executions"
-  default     = null
-}
-
 variable "runner_image" {
   type        = string
   description = "The full image name and tag of the Docker image to use in Spacelift"

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -13,6 +13,7 @@ resource "spacelift_stack" "default" {
   ]
 
   worker_pool_id    = var.worker_pool_id
+  runner_image      = var.runner_image
   terraform_version = var.terraform_version
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -14,7 +14,7 @@ resource "spacelift_stack" "default" {
 
   worker_pool_id    = var.worker_pool_id
   runner_image      = var.runner_image
-  before_init       = var.before_init
+  before_init       = [ for command in var.before_init : format(command, var.environment_name) ]
   terraform_version = var.terraform_version
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -14,7 +14,7 @@ resource "spacelift_stack" "default" {
 
   worker_pool_id    = var.worker_pool_id
   runner_image      = var.runner_image
-  #before_init       = [ for command in var.before_init : try(format(command, var.environment_name), command) ]
+  before_init       = [ for command in var.before_init : try(format(command, var.environment_name), command) ]
   terraform_version = var.terraform_version
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -14,7 +14,7 @@ resource "spacelift_stack" "default" {
 
   worker_pool_id    = var.worker_pool_id
   runner_image      = var.runner_image
-  before_init       = [ for command in var.before_init : format(command, var.environment_name) ]
+  before_init       = [ for command in var.before_init : try(format(command, var.environment_name), command) ]
   terraform_version = var.terraform_version
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -14,7 +14,7 @@ resource "spacelift_stack" "default" {
 
   worker_pool_id    = var.worker_pool_id
   runner_image      = var.runner_image
-  before_init       = [ for command in var.before_init : try(format(command, var.environment_name), command) ]
+  #before_init       = [ for command in var.before_init : try(format(command, var.environment_name), command) ]
   terraform_version = var.terraform_version
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -14,7 +14,6 @@ resource "spacelift_stack" "default" {
 
   worker_pool_id    = var.worker_pool_id
   runner_image      = var.runner_image
-  #before_init       = [ for command in var.before_init : try(format(command, var.environment_name), command) ]
   terraform_version = var.terraform_version
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -14,6 +14,7 @@ resource "spacelift_stack" "default" {
 
   worker_pool_id    = var.worker_pool_id
   runner_image      = var.runner_image
+  before_init       = var.before_init
   terraform_version = var.terraform_version
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -12,6 +12,7 @@ resource "spacelift_stack" "default" {
     for trigger in var.triggers : "depends-on:${trigger}|state:FINISHED"
   ]
 
+  worker_pool_id    = var.worker_pool_id
   terraform_version = var.terraform_version
 }
 

--- a/modules/stack/outputs.tf
+++ b/modules/stack/outputs.tf
@@ -5,6 +5,7 @@ output "config" {
     name              = spacelift_stack.default[0].name
     autodeploy        = spacelift_stack.default[0].autodeploy
     terraform_version = spacelift_stack.default[0].terraform_version
+    worker_pool_id    = spacelift_stack.default[0].worker_pool_id
     repository        = spacelift_stack.default[0].repository
     branch            = spacelift_stack.default[0].branch
   }, "disabled")

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -21,6 +21,12 @@ variable "terraform_version" {
   default     = null
 }
 
+variable "worker_pool_id" {
+  type        = string
+  description = "The immutable ID (slug) of the worker pool"
+  default     = null
+}
+
 variable "component_root" {
   type        = string
   description = "The path, relative to the root of the repository, where the component can be found"

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -27,9 +27,21 @@ variable "worker_pool_id" {
   default     = null
 }
 
+variable "role_arn" {
+  type        = string
+  description = "The role_arn to use for Spacelift executions"
+  default     = null
+}
+
 variable "runner_image" {
   type        = string
   description = "The full image name and tag of the Docker image to use in Spacelift"
+  default     = null
+}
+
+variable "before_init" {
+  type        = list
+  description = "A list of commands to execute in Spacelift before initializing Terraform"
   default     = null
 }
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -55,7 +55,7 @@ variable "environment_name" {
 }
 
 variable "environment_variables" {
-  type        = map
+  type        = map(any)
   default     = {}
   description = "The global values applied to all workspaces within the environment."
 }

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -39,12 +39,6 @@ variable "runner_image" {
   default     = null
 }
 
-variable "before_init" {
-  type        = list
-  description = "A list of commands to execute in Spacelift before initializing Terraform"
-  default     = null
-}
-
 variable "component_root" {
   type        = string
   description = "The path, relative to the root of the repository, where the component can be found"

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -61,7 +61,7 @@ variable "environment_variables" {
 }
 
 variable "triggers" {
-  type        = list
+  type        = list(any)
   default     = []
   description = "A list of other stacks that will trigger an execution."
 }

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -27,6 +27,12 @@ variable "worker_pool_id" {
   default     = null
 }
 
+variable "runner_image" {
+  type        = string
+  description = "The full image name and tag of the Docker image to use in Spacelift"
+  default     = null
+}
+
 variable "component_root" {
   type        = string
   description = "The path, relative to the root of the repository, where the component can be found"

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -98,6 +98,7 @@ variable "parent_context_id" {
 variable "autodeploy" {
   type        = bool
   description = "Controls the Spacelift 'autodeploy' option for a stack"
+  default     = false
 }
 
 variable "manage_state" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,27 @@ variable "external_execution" {
   description = "Set this to true if you're calling this module from outside of a Spacelift stack (e.g. the `complete` example)."
   default     = false
 }
+
+variable "worker_pool_id" {
+  type        = string
+  description = "The immutable ID (slug) of the worker pool"
+  default     = null
+}
+
+variable "role_arn" {
+  type        = string
+  description = "The role_arn to use for Spacelift executions"
+  default     = null
+}
+
+variable "runner_image" {
+  type        = string
+  description = "The full image name and tag of the Docker image to use in Spacelift"
+  default     = null
+}
+
+variable "before_init" {
+  type        = list
+  description = "A list of commands to execute in Spacelift before initializing Terraform"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -57,3 +57,8 @@ variable "runner_image" {
   default     = null
 }
 
+variable "autodeploy" {
+  type        = bool
+  description = "Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration)"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -45,12 +45,6 @@ variable "worker_pool_id" {
   default     = null
 }
 
-variable "role_arn" {
-  type        = string
-  description = "The role_arn to use for Spacelift executions"
-  default     = null
-}
-
 variable "runner_image" {
   type        = string
   description = "The full image name and tag of the Docker image to use in Spacelift"

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "manage_state" {
   default     = true
 }
 
+variable "terraform_version" {
+  type        = string
+  description = "Specify the version of Terraform to use for the stack"
+  default     = null
+}
+
 variable "external_execution" {
   type        = bool
   description = "Set this to true if you're calling this module from outside of a Spacelift stack (e.g. the `complete` example)."

--- a/variables.tf
+++ b/variables.tf
@@ -57,8 +57,3 @@ variable "runner_image" {
   default     = null
 }
 
-variable "before_init" {
-  type        = list
-  description = "A list of commands to execute in Spacelift before initializing Terraform"
-  default     = null
-}


### PR DESCRIPTION
# what

- Support for "older" YAML config format (`projects` instead of `components`)
- Adding ability to set global defaults for `terraform_version`, `worker_pool_id`, and `runner_image`
- Defaulting `autodeploy` to `false`, for obvious reasons
- Defaulting `workspace_enabled` to true to dry up some config
- Fixing environment variables so that values are json encoded (for complex data structures)
- Trimming excess double quotes in context variables (although I'm open to other approaches)
- Formatting updates
- Documentation updates
