### PR TITLE
Adding support for branch override & updating example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2020 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,6 +6,7 @@ module "example" {
   stack_config_path = var.stack_config_path
   branch            = var.branch
   repository        = var.repository
+  terraform_version = "0.13.5"
 
   external_execution = true
 }

--- a/examples/complete/stacks/gbl-root.yaml
+++ b/examples/complete/stacks/gbl-root.yaml
@@ -1,4 +1,4 @@
-components:
+projects:
   globals:
     stage: testing
     environment: gbl

--- a/examples/complete/stacks/ue2-testing.yaml
+++ b/examples/complete/stacks/ue2-testing.yaml
@@ -1,4 +1,4 @@
-components:
+projects:
   globals:
     stage: testing
 

--- a/examples/complete/stacks/uw2-testing.yaml
+++ b/examples/complete/stacks/uw2-testing.yaml
@@ -1,4 +1,4 @@
-components:
+projects:
   globals:
     stage: testing
     environment: uw2
@@ -6,6 +6,7 @@ components:
   terraform:
     example2:
       workspace_enabled: true
+      branch: add-branch-override
       vars:
         my_input_var: "Hello world! This is example1. It's disabled!"
     example3:

--- a/examples/complete/stacks/uw2-testing.yaml
+++ b/examples/complete/stacks/uw2-testing.yaml
@@ -6,7 +6,6 @@ projects:
   terraform:
     example2:
       workspace_enabled: true
-      branch: add-branch-override
       vars:
         my_input_var: "Hello world! This is example1. It's disabled!"
     example3:

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -20,7 +20,7 @@ module "components" {
   autodeploy            = coalesce(try(each.value.autodeploy, null), var.autodeploy)
   component_root        = format("%s/%s", var.components_path, try(each.value.custom_component_folder, each.value.component))
   repository            = var.repository
-  branch                = var.branch
+  branch                = coalesce(try(each.value.branch, null), var.branch)
   manage_state          = var.manage_state
   environment_variables = { for k, v in each.value.vars : k => jsonencode(v) }
   terraform_version     = coalesce(try(each.value.terraform_version, null), var.terraform_version)


### PR DESCRIPTION
## what
- Adding support for branch override at the project/component level
- Updating the example project because a couple things were out of date!

## why
- This will allow us to deploy Terraform from specific branches during the early development cycle (e.g. `sandbox`).


