### PR TITLE
Support use of atmos to generate vars file

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Available targets:
 |------|--------|---------|
 | <a name="module_spacelift_environment"></a> [spacelift\_environment](#module\_spacelift\_environment) | ./modules/environment |  |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.10.0 |
+| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.13.0 |
 
 ## Resources
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 |------|--------|---------|
 | <a name="module_spacelift_environment"></a> [spacelift\_environment](#module\_spacelift\_environment) | ./modules/environment |  |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.10.0 |
+| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.13.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "yaml_stack_config" {
   for_each = toset(var.stack_config_files)
 
   source  = "cloudposse/stack-config/yaml"
-  version = "0.10.0"
+  version = "0.13.0"
 
   stack_config_local_path = local.stack_config_path
   stacks                  = [trimsuffix(each.key, ".yaml")]

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -8,6 +8,7 @@ module "stacks" {
 
   enabled             = try(each.value.settings.spacelift.workspace_enabled, false)
   stack_name          = each.key
+  stack_config_name   = var.stack_config_name
   component_name      = coalesce(each.value.component, each.value.component_name)
   autodeploy          = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
   component_root      = format("%s/%s", var.components_path, coalesce(each.value.component, each.value.component_name))

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -8,6 +8,7 @@ module "stacks" {
 
   enabled             = try(each.value.settings.spacelift.workspace_enabled, false)
   stack_name          = each.key
+  component_name      = coalesce(each.value.component, each.value.component_name)
   autodeploy          = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
   component_root      = format("%s/%s", var.components_path, coalesce(each.value.component, each.value.component_name))
   repository          = var.repository

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -18,15 +18,21 @@ resource "spacelift_stack" "default" {
   terraform_workspace = var.terraform_workspace
 }
 
-resource "spacelift_mounted_file" "stack_config" {
+resource "spacelift_environment_variable" "stack_name" {
   count = var.enabled ? 1 : 0
 
-  stack_id      = spacelift_stack.default[0].id
-  relative_path = format("source/%s/spacelift.auto.tfvars.json", var.component_root)
-  content = base64encode(jsonencode({
-    for k, v in var.component_vars : k => jsondecode(v)
-  }))
+  stack_id   = spacelift_stack.default[0].id
+  name       = "ATMOS_STACK"
+  value      = var.stack_name
+  write_only = false
+}
 
+resource "spacelift_environment_variable" "component_name" {
+  count = var.enabled ? 1 : 0
+
+  stack_id   = spacelift_stack.default[0].id
+  name       = "ATMOS_COMPONENT"
+  value      = var.component_name
   write_only = false
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -35,7 +35,7 @@ resource "spacelift_environment_variable" "stack_name" {
 
   stack_id   = spacelift_stack.default[0].id
   name       = "ATMOS_STACK"
-  value      = var.stack_name
+  value      = var.stack_config_name
   write_only = false
 }
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -18,6 +18,18 @@ resource "spacelift_stack" "default" {
   terraform_workspace = var.terraform_workspace
 }
 
+resource "spacelift_mounted_file" "stack_config" {
+  count = var.enabled ? 1 : 0
+
+  stack_id      = spacelift_stack.default[0].id
+  relative_path = format("source/%s/spacelift.auto.tfvars.json", var.component_root)
+  content = base64encode(jsonencode({
+  for k, v in var.component_vars : k => jsondecode(v)
+  }))
+
+  write_only = false
+}
+
 resource "spacelift_environment_variable" "stack_name" {
   count = var.enabled ? 1 : 0
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -55,6 +55,11 @@ variable "stack_name" {
   description = "The name of the stack"
 }
 
+variable "stack_config_name" {
+  type        = string
+  description = "The name of the stack configuration (Atmos stack name)"
+}
+
 variable "component_name" {
   type        = string
   description = "The name of the component"

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -55,6 +55,11 @@ variable "stack_name" {
   description = "The name of the stack"
 }
 
+variable "component_name" {
+  type        = string
+  description = "The name of the component"
+}
+
 variable "component_vars" {
   type        = map(any)
   default     = {}

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -25,6 +25,10 @@ ignore  {
 }
 ignore  { input.push.tag != "" }
 
+# If pre-commit hooks make changes, they are not semantic changes
+# and can and should be ignored.
+ignore  { input.push.message == "pre-commit fixes" }
+
 # Fetch all of our affected files
 filepath := input.push.affected_files
 


### PR DESCRIPTION
## what
- Support use of `atmos` to generate vars file
- Ignore commits with message "pre-commit fixes"

## why
- Vars need to be up-to-date at all times during a PR lifecycle
- Pre-commit should not be making semantic changes and thus we can avoid having it trigger a second run

## notes

Supersedes and closes #15 