### PR TITLE
Use logical component name for Atmos

### DIFF
--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -9,6 +9,7 @@ module "stacks" {
   enabled             = try(each.value.settings.spacelift.workspace_enabled, false)
   stack_name          = each.key
   stack_config_name   = var.stack_config_name
+  logical_component   = each.value.component_name
   component_name      = coalesce(each.value.component, each.value.component_name)
   autodeploy          = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
   component_root      = format("%s/%s", var.components_path, coalesce(each.value.component, each.value.component_name))

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -44,7 +44,7 @@ resource "spacelift_environment_variable" "component_name" {
 
   stack_id   = spacelift_stack.default[0].id
   name       = "ATMOS_COMPONENT"
-  value      = var.component_name
+  value      = var.logical_component
   write_only = false
 }
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -62,8 +62,14 @@ variable "stack_config_name" {
 
 variable "component_name" {
   type        = string
-  description = "The name of the component"
+  description = "The name of the concrete component (typically a directory name)"
 }
+
+variable "logical_component" {
+  type        = string
+  description = "The name of the component (may be an alternate instance of a concrete component)"
+}
+
 
 variable "component_vars" {
   type        = map(any)


### PR DESCRIPTION
## what
- Use logical component name for Atmos

## why
- Atmos CLI takes logical component name as argument