### PR TITLE
Add global "plan" policy to wait for confirmation after failure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,8 @@
 
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
-**/*.tf       @cloudposse/engineering @cloudposse/approvers
-README.yaml   @cloudposse/engineering @cloudposse/approvers
+**/*.tf       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+README.yaml   @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,5 +1,7 @@
 name: Validate Codeowners
 on:
+  workflow_dispatch:
+
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Available targets:
 | Name | Type |
 |------|------|
 
+| spacelift_policy.plan | resource |
+
 | spacelift_policy.push | resource |
 
 | spacelift_policy.trigger_dependency | resource |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -25,6 +25,8 @@
 | Name | Type |
 |------|------|
 
+| spacelift_policy.plan | resource |
+
 | spacelift_policy.push | resource |
 
 | spacelift_policy.trigger_dependency | resource |

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "spacelift_policy" "plan" {
   type = "PLAN"
 
   name = "Global Plan Policy"
-  body = file("${path.module}/policies/plan.rego")
+  body = file("${path.module}/policies/plan-global.rego")
 }
 
 data "spacelift_current_stack" "this" {

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "spacelift_environment" {
 
   trigger_policy_id = spacelift_policy.trigger_global.id
   push_policy_id    = spacelift_policy.push.id
+  plan_policy_id    = spacelift_policy.plan.id
   stack_config_name = trimsuffix(each.key, ".yaml")
   components        = try(module.yaml_stack_config[each.key].config.0.components.terraform, {})
   components_path   = var.components_path
@@ -58,6 +59,14 @@ resource "spacelift_policy" "push" {
 
   name = "Global Push Policy"
   body = file("${path.module}/policies/push-global.rego")
+}
+
+# Define a global "plan" policy that stops and waits for confirmation after a plan fails
+resource "spacelift_policy" "plan" {
+  type = "PLAN"
+
+  name = "Global Plan Policy"
+  body = file("${path.module}/policies/plan.rego")
 }
 
 data "spacelift_current_stack" "this" {

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -24,4 +24,5 @@ module "stacks" {
   triggers            = coalesce(try(each.value.settings.spacelift.triggers, null), [])
   trigger_policy_id   = var.trigger_policy_id
   push_policy_id      = var.push_policy_id
+  plan_policy_id      = var.plan_policy_id
 }

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -21,6 +21,12 @@ variable "push_policy_id" {
   description = "ID for the component-level push policy."
 }
 
+variable "plan_policy_id" {
+  type        = string
+  default     = null
+  description = "ID for the project-level plan policy."
+}
+
 variable "components" {
   type        = any
   default     = {}

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -54,3 +54,10 @@ resource "spacelift_policy_attachment" "push" {
   policy_id = var.push_policy_id
   stack_id  = spacelift_stack.default[0].id
 }
+
+resource "spacelift_policy_attachment" "plan" {
+  count = var.enabled ? 1 : 0
+
+  policy_id = var.plan_policy_id
+  stack_id  = spacelift_stack.default[0].id
+}

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -95,6 +95,12 @@ variable "push_policy_id" {
   description = "ID for the project-level push policy."
 }
 
+variable "plan_policy_id" {
+  type        = string
+  default     = null
+  description = "ID for the project-level plan policy."
+}
+
 variable "autodeploy" {
   type        = bool
   description = "Controls the Spacelift 'autodeploy' option for a stack"

--- a/policies/plan-global.rego
+++ b/policies/plan-global.rego
@@ -1,3 +1,5 @@
+package spacelift
+
 warn["Previous run did not succeed, review this one manually"] {
  input.spacelift.previous_run.state == "FAILED"
 }

--- a/policies/plan.rego
+++ b/policies/plan.rego
@@ -1,0 +1,3 @@
+warn["Previous run did not succeed, review this one manually"] {
+ input.spacelift.previous_run.state == "FAILED"
+}


### PR DESCRIPTION
## what
- Add global "plan" policy to wait for confirmation after failure

## why
- We do not want Spacelift to steamroll past failures, which it does by default