### PR TITLE
[WIP] Destroy on Delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Available targets:
 |------|--------|---------|
 | <a name="module_spacelift_environment"></a> [spacelift\_environment](#module\_spacelift\_environment) | ./modules/environment |  |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.14.0 |
+| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.15.1 |
 
 ## Resources
 
@@ -240,6 +240,7 @@ Available targets:
 | <a name="input_components_path"></a> [components\_path](#input\_components\_path) | The relative pathname for where all components reside | `string` | `"components"` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_destroy_on_delete_enabled"></a> [destroy\_on\_delete\_enabled](#input\_destroy\_on\_delete\_enabled) | If `true`, Spacelift will destroy all the resources in the stack before destroying the stack itself. | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_external_execution"></a> [external\_execution](#input\_external\_execution) | Set this to true if you're calling this module from outside of a Spacelift stack (e.g. the `complete` example). | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 |------|--------|---------|
 | <a name="module_spacelift_environment"></a> [spacelift\_environment](#module\_spacelift\_environment) | ./modules/environment |  |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.14.0 |
+| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.15.1 |
 
 ## Resources
 
@@ -48,6 +48,7 @@
 | <a name="input_components_path"></a> [components\_path](#input\_components\_path) | The relative pathname for where all components reside | `string` | `"components"` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_destroy_on_delete_enabled"></a> [destroy\_on\_delete\_enabled](#input\_destroy\_on\_delete\_enabled) | If `true`, Spacelift will destroy all the resources in the stack before destroying the stack itself. | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_external_execution"></a> [external\_execution](#input\_external\_execution) | Set this to true if you're calling this module from outside of a Spacelift stack (e.g. the `complete` example). | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "yaml_stack_config" {
   for_each = toset(var.stack_config_files)
 
   source  = "cloudposse/stack-config/yaml"
-  version = "0.14.0"
+  version = "0.15.1"
 
   stack_config_local_path = local.stack_config_path
   stacks                  = [trimsuffix(each.key, ".yaml")]
@@ -33,6 +33,9 @@ module "spacelift_environment" {
   runner_image      = var.runner_image
   terraform_version = var.terraform_version
   autodeploy        = var.autodeploy
+
+  destroy_on_delete_enabled = var.destroy_on_delete_enabled
+
 
   terraform_version_map = var.terraform_version_map
 }

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -25,4 +25,7 @@ module "stacks" {
   trigger_policy_id   = var.trigger_policy_id
   push_policy_id      = var.push_policy_id
   plan_policy_id      = var.plan_policy_id
+
+  destroy_on_delete_enabled = var.destroy_on_delete_enabled
+
 }

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -85,3 +85,9 @@ variable "autodeploy" {
   description = "Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration)"
   default     = null
 }
+
+variable "destroy_on_delete_enabled" {
+  type        = bool
+  description = "If `true`, Spacelift will destroy all the resources in the stack before destroying the stack itself."
+  default     = false
+}

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -61,3 +61,16 @@ resource "spacelift_policy_attachment" "plan" {
   policy_id = var.plan_policy_id
   stack_id  = spacelift_stack.default[0].id
 }
+
+resource "spacelift_stack_destructor" "default" {
+  count = var.enabled && var.destroy_on_delete_enabled ? 1 : 0
+
+  depends_on = [
+    spacelift_mounted_file.stack_config,
+    spacelift_environment_variable.stack_name,
+    spacelift_environment_variable.component_name,
+    spacelift_policy_attachment.push,
+    spacelift_policy_attachment.plan,
+  ]
+  stack_id = spacelift_stack.default.id
+}

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -112,3 +112,9 @@ variable "manage_state" {
   description = "Flag to enable/disable manage_state setting in stack"
   default     = true
 }
+
+variable "destroy_on_delete_enabled" {
+  type        = bool
+  description = "If `true`, Spacelift will destroy all the resources in the stack before destroying the stack itself."
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -68,3 +68,9 @@ variable "autodeploy" {
   description = "Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration)"
   default     = false
 }
+
+variable "destroy_on_delete_enabled" {
+  type        = bool
+  description = "If `true`, Spacelift will destroy all the resources in the stack before destroying the stack itself."
+  default     = false
+}


### PR DESCRIPTION
## notes

This is so dangerous we might not want to do it at all. For sure we want to default to disabled and only enable it on a per-stack bases via a stack setting. At the moment, the PR only enables it for all stacks regardless of settings.

---

## what
- Add a feature that tells Spacelift to destroy the resources of a Stack before deleting it

## why
- Without this feature, deleting a Stack would leave resources abandoned


## references
- [spacelift_stack_destructor-resource](https://github.com/spacelift-io/terraform-provider-spacelift#spacelift_stack_destructor-resource)