### PR TITLE
Add support for Spacelift folders. Implement Spacelift triggers policy per component based on stack configs & imports. Add support for Spacelift automated retries

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,9 @@ name: auto-release
 on:
   push:
     branches:
+      - main
       - master
+      - production
 
 jobs:
   publish:
@@ -14,7 +16,7 @@ jobs:
         id: get-merged-pull-request
         with:
           github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Cloud Posse, LLC
+   Copyright 2020-2021 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -223,8 +223,6 @@ Available targets:
 
 | spacelift_policy.trigger_global | resource |
 
-| spacelift_policy.trigger_retries | resource |
-
 | spacelift_policy_attachment.trigger_global | resource |
 
 | spacelift_current_stack.this | data source |

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@
 
 -->
 
-This project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
-use when creating new repositories.
+Terraform module to provision [Spacelift](https://spacelift.io/) resources for cloud infrastructure automation.
 
 ---
 
@@ -268,6 +267,211 @@ Available targets:
 <!-- markdownlint-restore -->
 
 
+
+## Share the Love
+
+Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation)! (it helps us **a lot**)
+
+Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
+
+
 ## Related Projects
 
 Check out these related projects.
+
+- [terraform-provider-utils](https://github.com/cloudposse/terraform-provider-utils) - The Cloud Posse Terraform Provider for various utilities.
+- [terraform-yaml-stack-config](https://github.com/cloudposse/terraform-yaml-stack-config) - Terraform module that loads an opinionated stack configuration from local or remote YAML sources. It supports deep-merged variables, settings, ENV variables, backend config, and remote state outputs for Terraform and helmfile components.
+- [terraform-yaml-config](https://github.com/cloudposse/terraform-yaml-config) - Terraform module to convert local and remote YAML configuration templates into Terraform lists and maps.
+
+
+
+
+## References
+
+For additional context, refer to some of these links.
+
+- [Terraform Version Pinning](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version) - The required_version setting can be used to constrain which versions of the Terraform CLI can be used with your configuration
+- [Spacelift](https://spacelift.io/) - The most flexible CI/CD for Terraform
+- [Spacelift Documentation](https://docs.spacelift.io/) - Official documentation site for Spacelift
+- [Open Policy Agent](https://www.openpolicyagent.org/) - Policy-based control for cloud native environments
+- [OPA Documentation](https://www.openpolicyagent.org/docs/latest/) - Open Policy Agent Documentation
+- [Rego - OPA’s query and policy language](https://www.openpolicyagent.org/docs/latest/policy-language/) - Rego focuses on providing powerful support for referencing nested documents and ensuring that queries are correct and unambiguous
+- [Example of using Rego policy language](https://blog.gripdev.xyz/2020/01/13/mutating-admissions-controllers-with-open-policy-agent-and-rego/) - Mutating Admissions Controllers with Open Policy Agent and Rego
+
+
+## Help
+
+**Got a question?** We got answers.
+
+File a GitHub [issue](https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/issues), send us an [email][email] or join our [Slack Community][slack].
+
+[![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
+
+## DevOps Accelerator for Startups
+
+
+We are a [**DevOps Accelerator**][commercial_support]. We'll help you build your cloud infrastructure from the ground up so you can own it. Then we'll show you how to operate it and stick around for as long as you need us.
+
+[![Learn More](https://img.shields.io/badge/learn%20more-success.svg?style=for-the-badge)][commercial_support]
+
+Work directly with our team of DevOps experts via email, slack, and video conferencing.
+
+We deliver 10x the value for a fraction of the cost of a full-time engineer. Our track record is not even funny. If you want things done right and you need it done FAST, then we're your best bet.
+
+- **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
+- **Release Engineering.** You'll have end-to-end CI/CD with unlimited staging environments.
+- **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
+- **Security Baseline.** You'll have built-in governance with accountability and audit logs for all changes.
+- **GitOps.** You'll be able to operate your infrastructure via Pull Requests.
+- **Training.** You'll receive hands-on training so your team can operate what we build.
+- **Questions.** You'll have a direct line of communication between our teams via a Shared Slack channel.
+- **Troubleshooting.** You'll get help to triage when things aren't working.
+- **Code Reviews.** You'll receive constructive feedback on Pull Requests.
+- **Bug Fixes.** We'll rapidly work with you to fix any bugs in our projects.
+
+## Slack Community
+
+Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
+
+## Newsletter
+
+Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
+
+## Office Hours
+
+[Join us every Wednesday via Zoom][office_hours] for our weekly "Lunch & Learn" sessions. It's **FREE** for everyone!
+
+[![zoom](https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png")][office_hours]
+
+## Contributing
+
+### Bug Reports & Feature Requests
+
+Please use the [issue tracker](https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/issues) to report any bugs or file feature requests.
+
+### Developing
+
+If you are interested in being a contributor and want to get involved in developing this project or [help out](https://cpco.io/help-out) with our other projects, we would love to hear from you! Shoot us an [email][email].
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** the project to your own machine
+ 3. **Commit** changes to your own branch
+ 4. **Push** your work back up to your fork
+ 5. Submit a **Pull Request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
+
+
+
+## Copyrights
+
+Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
+
+
+
+
+
+## License
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+See [LICENSE](LICENSE) for full details.
+
+```text
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+```
+
+
+
+
+
+
+
+
+
+## Trademarks
+
+All other trademarks referenced herein are the property of their respective owners.
+
+## About
+
+This project is maintained and funded by [Cloud Posse, LLC][website]. Like it? Please let us know by [leaving a testimonial][testimonial]!
+
+[![Cloud Posse][logo]][website]
+
+We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. We ❤️  [Open Source Software][we_love_open_source].
+
+We offer [paid support][commercial_support] on all of our projects.
+
+Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
+
+
+
+### Contributors
+
+<!-- markdownlint-disable -->
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Dan Meyers][danjbh_avatar]][danjbh_homepage]<br/>[Dan Meyers][danjbh_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] |
+|---|---|---|
+<!-- markdownlint-restore -->
+
+  [osterman_homepage]: https://github.com/osterman
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
+  [danjbh_homepage]: https://github.com/danjbh
+  [danjbh_avatar]: https://img.cloudposse.com/150x150/https://github.com/danjbh.png
+  [aknysh_homepage]: https://github.com/aknysh
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
+
+[![README Footer][readme_footer_img]][readme_footer_link]
+[![Beacon][beacon]][website]
+
+  [logo]: https://cloudposse.com/logo-300x69.svg
+  [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=docs
+  [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=website
+  [github]: https://cpco.io/github?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=github
+  [jobs]: https://cpco.io/jobs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=jobs
+  [hire]: https://cpco.io/hire?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=hire
+  [slack]: https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=slack
+  [linkedin]: https://cpco.io/linkedin?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=linkedin
+  [twitter]: https://cpco.io/twitter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=twitter
+  [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=testimonial
+  [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=office_hours
+  [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=discourse
+  [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=email
+  [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=commercial_support
+  [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=we_love_open_source
+  [terraform_modules]: https://cpco.io/terraform-modules?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=terraform_modules
+  [readme_header_img]: https://cloudposse.com/readme/header/img
+  [readme_header_link]: https://cloudposse.com/readme/header/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=readme_header_link
+  [readme_footer_img]: https://cloudposse.com/readme/footer/img
+  [readme_footer_link]: https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=readme_footer_link
+  [readme_commercial_support_img]: https://cloudposse.com/readme/commercial-support/img
+  [readme_commercial_support_link]: https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=readme_commercial_support_link
+  [share_twitter]: https://twitter.com/intent/tweet/?text=terraform-spacelift-cloud-infrastructure-automation&url=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
+  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=terraform-spacelift-cloud-infrastructure-automation&url=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
+  [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
+  [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
+  [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
+  [share_email]: mailto:?subject=terraform-spacelift-cloud-infrastructure-automation&body=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
+  [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-spacelift-cloud-infrastructure-automation?pixel&cs=github&cm=readme&an=terraform-spacelift-cloud-infrastructure-automation

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-spacelift-cloud-infrastructure-automation
 
@@ -32,7 +33,6 @@
 This project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
 use when creating new repositories.
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -57,7 +57,6 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
-
 
 
 
@@ -210,7 +209,7 @@ Available targets:
 |------|--------|---------|
 | <a name="module_spacelift_environment"></a> [spacelift\_environment](#module\_spacelift\_environment) | ./modules/environment |  |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.14.0 |
+| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.15.2 |
 
 ## Resources
 
@@ -269,190 +268,6 @@ Available targets:
 <!-- markdownlint-restore -->
 
 
+## Related Projects
 
-
-## References
-
-For additional context, refer to some of these links.
-
-- [Terraform Version Pinning](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version) - The required_version setting can be used to constrain which versions of the Terraform CLI can be used with your configuration
-- [Spacelift](https://spacelift.io/) - The most flexible CI/CD for Terraform
-- [Spacelift Documentation](https://docs.spacelift.io/) - Official documentation site for Spacelift
-
-
-## Help
-
-**Got a question?** We got answers.
-
-File a GitHub [issue](https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/issues), send us an [email][email] or join our [Slack Community][slack].
-
-[![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
-
-## DevOps Accelerator for Startups
-
-
-We are a [**DevOps Accelerator**][commercial_support]. We'll help you build your cloud infrastructure from the ground up so you can own it. Then we'll show you how to operate it and stick around for as long as you need us.
-
-[![Learn More](https://img.shields.io/badge/learn%20more-success.svg?style=for-the-badge)][commercial_support]
-
-Work directly with our team of DevOps experts via email, slack, and video conferencing.
-
-We deliver 10x the value for a fraction of the cost of a full-time engineer. Our track record is not even funny. If you want things done right and you need it done FAST, then we're your best bet.
-
-- **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
-- **Release Engineering.** You'll have end-to-end CI/CD with unlimited staging environments.
-- **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
-- **Security Baseline.** You'll have built-in governance with accountability and audit logs for all changes.
-- **GitOps.** You'll be able to operate your infrastructure via Pull Requests.
-- **Training.** You'll receive hands-on training so your team can operate what we build.
-- **Questions.** You'll have a direct line of communication between our teams via a Shared Slack channel.
-- **Troubleshooting.** You'll get help to triage when things aren't working.
-- **Code Reviews.** You'll receive constructive feedback on Pull Requests.
-- **Bug Fixes.** We'll rapidly work with you to fix any bugs in our projects.
-
-## Slack Community
-
-Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
-
-## Discourse Forums
-
-Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
-
-## Newsletter
-
-Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
-
-## Office Hours
-
-[Join us every Wednesday via Zoom][office_hours] for our weekly "Lunch & Learn" sessions. It's **FREE** for everyone!
-
-[![zoom](https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png")][office_hours]
-
-## Contributing
-
-### Bug Reports & Feature Requests
-
-Please use the [issue tracker](https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/issues) to report any bugs or file feature requests.
-
-### Developing
-
-If you are interested in being a contributor and want to get involved in developing this project or [help out](https://cpco.io/help-out) with our other projects, we would love to hear from you! Shoot us an [email][email].
-
-In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
-
- 1. **Fork** the repo on GitHub
- 2. **Clone** the project to your own machine
- 3. **Commit** changes to your own branch
- 4. **Push** your work back up to your fork
- 5. Submit a **Pull Request** so that we can review your changes
-
-**NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
-
-
-
-## Copyrights
-
-Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
-
-
-
-
-
-## License
-
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-See [LICENSE](LICENSE) for full details.
-
-```text
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-```
-
-
-
-
-
-
-
-
-
-## Trademarks
-
-All other trademarks referenced herein are the property of their respective owners.
-
-## About
-
-This project is maintained and funded by [Cloud Posse, LLC][website]. Like it? Please let us know by [leaving a testimonial][testimonial]!
-
-[![Cloud Posse][logo]][website]
-
-We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. We ❤️  [Open Source Software][we_love_open_source].
-
-We offer [paid support][commercial_support] on all of our projects.
-
-Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
-
-
-
-### Contributors
-
-<!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Dan Meyers][danjbh_avatar]][danjbh_homepage]<br/>[Dan Meyers][danjbh_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] |
-|---|---|---|
-<!-- markdownlint-restore -->
-
-  [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
-  [danjbh_homepage]: https://github.com/danjbh
-  [danjbh_avatar]: https://img.cloudposse.com/150x150/https://github.com/danjbh.png
-  [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
-
-[![README Footer][readme_footer_img]][readme_footer_link]
-[![Beacon][beacon]][website]
-
-  [logo]: https://cloudposse.com/logo-300x69.svg
-  [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=docs
-  [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=website
-  [github]: https://cpco.io/github?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=github
-  [jobs]: https://cpco.io/jobs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=jobs
-  [hire]: https://cpco.io/hire?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=hire
-  [slack]: https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=slack
-  [linkedin]: https://cpco.io/linkedin?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=linkedin
-  [twitter]: https://cpco.io/twitter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=twitter
-  [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=testimonial
-  [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=office_hours
-  [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=newsletter
-  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=discourse
-  [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=email
-  [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=commercial_support
-  [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=we_love_open_source
-  [terraform_modules]: https://cpco.io/terraform-modules?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=terraform_modules
-  [readme_header_img]: https://cloudposse.com/readme/header/img
-  [readme_header_link]: https://cloudposse.com/readme/header/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=readme_header_link
-  [readme_footer_img]: https://cloudposse.com/readme/footer/img
-  [readme_footer_link]: https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=readme_footer_link
-  [readme_commercial_support_img]: https://cloudposse.com/readme/commercial-support/img
-  [readme_commercial_support_link]: https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-spacelift-cloud-infrastructure-automation&utm_content=readme_commercial_support_link
-  [share_twitter]: https://twitter.com/intent/tweet/?text=terraform-spacelift-cloud-infrastructure-automation&url=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
-  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=terraform-spacelift-cloud-infrastructure-automation&url=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
-  [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
-  [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
-  [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
-  [share_email]: mailto:?subject=terraform-spacelift-cloud-infrastructure-automation&body=https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation
-  [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-spacelift-cloud-infrastructure-automation?pixel&cs=github&cm=readme&an=terraform-spacelift-cloud-infrastructure-automation
+Check out these related projects.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Available targets:
 | <a name="input_manage_state"></a> [manage\_state](#input\_manage\_state) | Global flag to enable/disable manage\_state settings for all project stacks. | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_process_component_stack_deps"></a> [process\_component\_stack\_deps](#input\_process\_component\_stack\_deps) | Enable/disable processing stack dependencies for components | `bool` | `false` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | The name of your infrastructure repo | `string` | n/a | yes |
 | <a name="input_runner_image"></a> [runner\_image](#input\_runner\_image) | The full image name and tag of the Docker image to use in Spacelift | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Available targets:
 |------|--------|---------|
 | <a name="module_spacelift_environment"></a> [spacelift\_environment](#module\_spacelift\_environment) | ./modules/environment |  |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.15.2 |
+| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.15.3 |
 
 ## Resources
 
@@ -252,7 +252,7 @@ Available targets:
 | <a name="input_repository"></a> [repository](#input\_repository) | The name of your infrastructure repo | `string` | n/a | yes |
 | <a name="input_runner_image"></a> [runner\_image](#input\_runner\_image) | The full image name and tag of the Docker image to use in Spacelift | `string` | `null` | no |
 | <a name="input_stack_config_files"></a> [stack\_config\_files](#input\_stack\_config\_files) | A list of stack config files | `list(any)` | `[]` | no |
-| <a name="input_stack_config_path"></a> [stack\_config\_path](#input\_stack\_config\_path) | Relative path to YAML config files | `string` | `null` | no |
+| <a name="input_stack_config_path"></a> [stack\_config\_path](#input\_stack\_config\_path) | Relative path to YAML config files | `string` | `"stacks"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Specify the version of Terraform to use for the stack | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Available targets:
 
 | spacelift_policy_attachment.trigger_global | resource |
 
+| spacelift_policy_attachment.trigger_retries | resource |
+
 | spacelift_current_stack.this | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The table below correctly indicates which inputs are required.
 
 
 
-The first step is to create a new infrastructure repository in Github and link it in Spacelift. You will want the `Project root` 
+The first step is to create a new infrastructure repository in GitHub and link it in Spacelift. You will want the `Project root`
 of the infrastructure repository to point to the `top-level` project that contains the reference to this module. Beyond that,
 you will also want to enable the `Administrative` and `Autodeploy` options in the configuration.
 
@@ -412,14 +412,16 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Dan Meyers][danjbh_avatar]][danjbh_homepage]<br/>[Dan Meyers][danjbh_homepage] |
-|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Dan Meyers][danjbh_avatar]][danjbh_homepage]<br/>[Dan Meyers][danjbh_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] |
+|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [danjbh_homepage]: https://github.com/danjbh
   [danjbh_avatar]: https://img.cloudposse.com/150x150/https://github.com/danjbh.png
+  [aknysh_homepage]: https://github.com/aknysh
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Available targets:
 
 | spacelift_policy.trigger_global | resource |
 
+| spacelift_policy.trigger_retries | resource |
+
 | spacelift_policy_attachment.trigger_global | resource |
 
 | spacelift_current_stack.this | data source |
@@ -257,6 +259,8 @@ Available targets:
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Specify the version of Terraform to use for the stack | `string` | `null` | no |
 | <a name="input_terraform_version_map"></a> [terraform\_version\_map](#input\_terraform\_version\_map) | A map to determine which Terraform patch version to use for each minor version | `map(string)` | `{}` | no |
+| <a name="input_trigger_global_enabled"></a> [trigger\_global\_enabled](#input\_trigger\_global\_enabled) | Flag to enable/disable the global trigger | `bool` | `false` | no |
+| <a name="input_trigger_retries_enabled"></a> [trigger\_retries\_enabled](#input\_trigger\_retries\_enabled) | Flag to enable/disable the automatic retries trigger | `bool` | `false` | no |
 | <a name="input_worker_pool_id"></a> [worker\_pool\_id](#input\_worker\_pool\_id) | The immutable ID (slug) of the worker pool | `string` | `null` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Available targets:
 
 | spacelift_policy.trigger_global | resource |
 
+| spacelift_policy.trigger_retries | resource |
+
 | spacelift_policy_attachment.trigger_global | resource |
 
 | spacelift_current_stack.this | data source |

--- a/README.yaml
+++ b/README.yaml
@@ -40,6 +40,17 @@ badges:
 #     description:
 #     url:
 
+related:
+  - name: "terraform-provider-utils"
+    description: "The Cloud Posse Terraform Provider for various utilities."
+    url: "https://github.com/cloudposse/terraform-provider-utils"
+  - name: "terraform-yaml-stack-config"
+    description: "Terraform module that loads an opinionated stack configuration from local or remote YAML sources. It supports deep-merged variables, settings, ENV variables, backend config, and remote state outputs for Terraform and helmfile components."
+    url: "https://github.com/cloudposse/terraform-yaml-stack-config"
+  - name: "terraform-yaml-config"
+    description: "Terraform module to convert local and remote YAML configuration templates into Terraform lists and maps."
+    url: "https://github.com/cloudposse/terraform-yaml-config"
+
 # List any resources helpful for someone to get started. For example, link to the hashicorp documentation or AWS documentation.
 references:
   - name: "Terraform Version Pinning"
@@ -51,11 +62,22 @@ references:
   - name: "Spacelift Documentation"
     description: "Official documentation site for Spacelift"
     url: "https://docs.spacelift.io/"
+  - name: "Open Policy Agent"
+    description: "Policy-based control for cloud native environments"
+    url: "https://www.openpolicyagent.org/"
+  - name: "OPA Documentation"
+    description: "Open Policy Agent Documentation"
+    url: "https://www.openpolicyagent.org/docs/latest/"
+  - name: "Rego - OPA’s query and policy language"
+    description: "Rego focuses on providing powerful support for referencing nested documents and ensuring that queries are correct and unambiguous"
+    url: "https://www.openpolicyagent.org/docs/latest/policy-language/"
+  - name: "Example of using Rego policy language"
+    description: "Mutating Admissions Controllers with Open Policy Agent and Rego"
+    url: "https://blog.gripdev.xyz/2020/01/13/mutating-admissions-controllers-with-open-policy-agent-and-rego/"
 
 # Short description of this project
 description: |-
-  This project provides all the scaffolding for a typical well-built Cloud Posse module. It's a template repository you can
-  use when creating new repositories.
+  Terraform module to provision [Spacelift](https://spacelift.io/) resources for cloud infrastructure automation.
 
 # Introduction to the project
 #introduction: |-

--- a/README.yaml
+++ b/README.yaml
@@ -65,7 +65,7 @@ description: |-
 
 usage: |-
 
-  The first step is to create a new infrastructure repository in Github and link it in Spacelift. You will want the `Project root` 
+  The first step is to create a new infrastructure repository in GitHub and link it in Spacelift. You will want the `Project root`
   of the infrastructure repository to point to the `top-level` project that contains the reference to this module. Beyond that,
   you will also want to enable the `Administrative` and `Autodeploy` options in the configuration.
 
@@ -155,3 +155,5 @@ contributors:
     github: "osterman"
   - name: "Dan Meyers"
     github: "danjbh"
+  - name: "Andriy Knysh"
+    github: "aknysh"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -33,6 +33,8 @@
 
 | spacelift_policy.trigger_global | resource |
 
+| spacelift_policy.trigger_retries | resource |
+
 | spacelift_policy_attachment.trigger_global | resource |
 
 | spacelift_current_stack.this | data source |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -33,6 +33,8 @@
 
 | spacelift_policy.trigger_global | resource |
 
+| spacelift_policy.trigger_retries | resource |
+
 | spacelift_policy_attachment.trigger_global | resource |
 
 | spacelift_current_stack.this | data source |
@@ -67,6 +69,8 @@
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Specify the version of Terraform to use for the stack | `string` | `null` | no |
 | <a name="input_terraform_version_map"></a> [terraform\_version\_map](#input\_terraform\_version\_map) | A map to determine which Terraform patch version to use for each minor version | `map(string)` | `{}` | no |
+| <a name="input_trigger_global_enabled"></a> [trigger\_global\_enabled](#input\_trigger\_global\_enabled) | Flag to enable/disable the global trigger | `bool` | `false` | no |
+| <a name="input_trigger_retries_enabled"></a> [trigger\_retries\_enabled](#input\_trigger\_retries\_enabled) | Flag to enable/disable the automatic retries trigger | `bool` | `false` | no |
 | <a name="input_worker_pool_id"></a> [worker\_pool\_id](#input\_worker\_pool\_id) | The immutable ID (slug) of the worker pool | `string` | `null` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 |------|--------|---------|
 | <a name="module_spacelift_environment"></a> [spacelift\_environment](#module\_spacelift\_environment) | ./modules/environment |  |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.14.0 |
+| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.15.2 |
 
 ## Resources
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -60,6 +60,7 @@
 | <a name="input_manage_state"></a> [manage\_state](#input\_manage\_state) | Global flag to enable/disable manage\_state settings for all project stacks. | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_process_component_stack_deps"></a> [process\_component\_stack\_deps](#input\_process\_component\_stack\_deps) | Enable/disable processing stack dependencies for components | `bool` | `false` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | The name of your infrastructure repo | `string` | n/a | yes |
 | <a name="input_runner_image"></a> [runner\_image](#input\_runner\_image) | The full image name and tag of the Docker image to use in Spacelift | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -33,8 +33,6 @@
 
 | spacelift_policy.trigger_global | resource |
 
-| spacelift_policy.trigger_retries | resource |
-
 | spacelift_policy_attachment.trigger_global | resource |
 
 | spacelift_current_stack.this | data source |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -37,6 +37,8 @@
 
 | spacelift_policy_attachment.trigger_global | resource |
 
+| spacelift_policy_attachment.trigger_retries | resource |
+
 | spacelift_current_stack.this | data source |
 
 ## Inputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 |------|--------|---------|
 | <a name="module_spacelift_environment"></a> [spacelift\_environment](#module\_spacelift\_environment) | ./modules/environment |  |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
-| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.15.2 |
+| <a name="module_yaml_stack_config"></a> [yaml\_stack\_config](#module\_yaml\_stack\_config) | cloudposse/stack-config/yaml | 0.15.3 |
 
 ## Resources
 
@@ -62,7 +62,7 @@
 | <a name="input_repository"></a> [repository](#input\_repository) | The name of your infrastructure repo | `string` | n/a | yes |
 | <a name="input_runner_image"></a> [runner\_image](#input\_runner\_image) | The full image name and tag of the Docker image to use in Spacelift | `string` | `null` | no |
 | <a name="input_stack_config_files"></a> [stack\_config\_files](#input\_stack\_config\_files) | A list of stack config files | `list(any)` | `[]` | no |
-| <a name="input_stack_config_path"></a> [stack\_config\_path](#input\_stack\_config\_path) | Relative path to YAML config files | `string` | `null` | no |
+| <a name="input_stack_config_path"></a> [stack\_config\_path](#input\_stack\_config\_path) | Relative path to YAML config files | `string` | `"stacks"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | Specify the version of Terraform to use for the stack | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "spacelift_policy_attachment" "trigger_global" {
 }
 
 # Attach the Retries Trigger Policy to the current stack
-resource "spacelift_policy_attachment" "trigger_global" {
+resource "spacelift_policy_attachment" "trigger_retries" {
   count = var.external_execution == false && var.trigger_retries_enabled ? 1 : 0
 
   policy_id = join("", spacelift_policy.trigger_retries.*.id)

--- a/main.tf
+++ b/main.tf
@@ -58,12 +58,12 @@ resource "spacelift_policy" "trigger_dependency" {
 }
 
 # Define the automatic retries trigger policy that allows automatically restarting the failed run
-resource "spacelift_policy" "trigger_retries" {
-  type = "TRIGGER"
-
-  name = "Failed Run Automatic Retries Trigger Policy"
-  body = file("${path.module}/policies/trigger-retries.rego")
-}
+# resource "spacelift_policy" "trigger_retries" {
+#   type = "TRIGGER"
+#
+#  name = "Failed Run Automatic Retries Trigger Policy"
+#  body = file("${path.module}/policies/trigger-retries.rego")
+#}
 
 # Define the global "git push" policy that causes executions on stacks when `<component_root>/*.tf` is modified
 resource "spacelift_policy" "push" {

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ data "spacelift_current_stack" "this" {
 
 # Attach the Environment Trigger Policy to the current stack
 resource "spacelift_policy_attachment" "trigger_global" {
-  count = !var.external_execution && var.trigger_global_enabled ? 1 : 0
+  count = ! var.external_execution && var.trigger_global_enabled ? 1 : 0
 
   policy_id = join("", spacelift_policy.trigger_global.*.id)
   stack_id  = data.spacelift_current_stack.this[0].id
@@ -95,7 +95,7 @@ resource "spacelift_policy_attachment" "trigger_global" {
 
 # Attach the Retries Trigger Policy to the current stack
 resource "spacelift_policy_attachment" "trigger_global" {
-  count = !var.external_execution && var.trigger_retries_enabled ? 1 : 0
+  count = ! var.external_execution && var.trigger_retries_enabled ? 1 : 0
 
   policy_id = join("", spacelift_policy.trigger_retries.*.id)
   stack_id  = data.spacelift_current_stack.this[0].id

--- a/main.tf
+++ b/main.tf
@@ -82,12 +82,12 @@ resource "spacelift_policy" "plan" {
 }
 
 data "spacelift_current_stack" "this" {
-  count = var.external_execution ? 0 : 1
+  count = var.external_execution == false ? 1 : 0
 }
 
 # Attach the Environment Trigger Policy to the current stack
 resource "spacelift_policy_attachment" "trigger_global" {
-  count = ! var.external_execution && var.trigger_global_enabled ? 1 : 0
+  count = var.external_execution == false && var.trigger_global_enabled ? 1 : 0
 
   policy_id = join("", spacelift_policy.trigger_global.*.id)
   stack_id  = data.spacelift_current_stack.this[0].id
@@ -95,7 +95,7 @@ resource "spacelift_policy_attachment" "trigger_global" {
 
 # Attach the Retries Trigger Policy to the current stack
 resource "spacelift_policy_attachment" "trigger_global" {
-  count = ! var.external_execution && var.trigger_retries_enabled ? 1 : 0
+  count = var.external_execution == false && var.trigger_retries_enabled ? 1 : 0
 
   policy_id = join("", spacelift_policy.trigger_retries.*.id)
   stack_id  = data.spacelift_current_stack.this[0].id

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,8 @@ module "spacelift_environment" {
   terraform_version = var.terraform_version
   autodeploy        = var.autodeploy
 
-  terraform_version_map = var.terraform_version_map
+  terraform_version_map        = var.terraform_version_map
+  process_component_stack_deps = var.process_component_stack_deps
 }
 
 # Define the global trigger policy that allows us to trigger on various context-level updates

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "yaml_stack_config" {
   for_each = toset(var.stack_config_files)
 
   source  = "cloudposse/stack-config/yaml"
-  version = "0.15.2"
+  version = "0.15.3"
 
   stack_config_local_path = local.stack_config_path
   stacks                  = [trimsuffix(each.key, ".yaml")]
@@ -27,8 +27,9 @@ module "spacelift_environment" {
   plan_policy_id    = spacelift_policy.plan.id
   stack_config_name = trimsuffix(each.key, ".yaml")
   components        = try(module.yaml_stack_config[each.key].config.0.components.terraform, {})
-  imports           = try(module.yaml_stack_config[each.key].config.0.components.imports, [])
+  imports           = [for import in try(module.yaml_stack_config[each.key].config.0.imports, []) : format("%s/%s.yaml", local.stack_config_path, import)]
   components_path   = var.components_path
+  stack_config_path = local.stack_config_path
   repository        = var.repository
   branch            = var.branch
   manage_state      = var.manage_state

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,10 @@ module "yaml_stack_config" {
   context = module.this.context
 }
 
+locals {
+  terraform_components = try(module.yaml_stack_config[each.key].config.0.components.terraform, {})
+}
+
 module "spacelift_environment" {
   source = "./modules/environment"
 
@@ -26,7 +30,7 @@ module "spacelift_environment" {
   push_policy_id    = spacelift_policy.push.id
   plan_policy_id    = spacelift_policy.plan.id
   stack_config_name = trimsuffix(each.key, ".yaml")
-  components        = try(module.yaml_stack_config[each.key].config.0.components.terraform, {})
+  components        = local.terraform_components
   components_path   = var.components_path
   repository        = var.repository
   branch            = var.branch

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ module "spacelift_environment" {
 
   for_each = toset(var.stack_config_files)
 
-  trigger_policy_id = spacelift_policy.trigger_global.id
+  trigger_policy_id = join("", spacelift_policy.trigger_global.*.id)
   push_policy_id    = spacelift_policy.push.id
   plan_policy_id    = spacelift_policy.plan.id
   stack_config_name = trimsuffix(each.key, ".yaml")
@@ -87,8 +87,16 @@ data "spacelift_current_stack" "this" {
 
 # Attach the Environment Trigger Policy to the current stack
 resource "spacelift_policy_attachment" "trigger_global" {
-  count = var.external_execution ? 0 : 1
+  count = !var.external_execution && var.trigger_global_enabled ? 1 : 0
 
-  policy_id = spacelift_policy.trigger_global.id
+  policy_id = join("", spacelift_policy.trigger_global.*.id)
+  stack_id  = data.spacelift_current_stack.this[0].id
+}
+
+# Attach the Retries Trigger Policy to the current stack
+resource "spacelift_policy_attachment" "trigger_global" {
+  count = !var.external_execution && var.trigger_retries_enabled ? 1 : 0
+
+  policy_id = join("", spacelift_policy.trigger_retries.*.id)
   stack_id  = data.spacelift_current_stack.this[0].id
 }

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,12 @@ module "yaml_stack_config" {
   for_each = toset(var.stack_config_files)
 
   source  = "cloudposse/stack-config/yaml"
-  version = "0.14.0"
+  version = "0.15.2"
 
   stack_config_local_path = local.stack_config_path
   stacks                  = [trimsuffix(each.key, ".yaml")]
+
+  process_component_stack_deps = true
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,6 @@ module "yaml_stack_config" {
   context = module.this.context
 }
 
-locals {
-  terraform_components = try(module.yaml_stack_config[each.key].config.0.components.terraform, {})
-}
-
 module "spacelift_environment" {
   source = "./modules/environment"
 
@@ -30,7 +26,8 @@ module "spacelift_environment" {
   push_policy_id    = spacelift_policy.push.id
   plan_policy_id    = spacelift_policy.plan.id
   stack_config_name = trimsuffix(each.key, ".yaml")
-  components        = local.terraform_components
+  components        = try(module.yaml_stack_config[each.key].config.0.components.terraform, {})
+  imports           = try(module.yaml_stack_config[each.key].config.0.components.imports, [])
   components_path   = var.components_path
   repository        = var.repository
   branch            = var.branch

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,14 @@ resource "spacelift_policy" "trigger_dependency" {
   body = file("${path.module}/policies/trigger-dependencies.rego")
 }
 
+# Define the automatic retries trigger policy that allows automatically restarting the failed run
+resource "spacelift_policy" "trigger_retries" {
+  type = "TRIGGER"
+
+  name = "Failed Run Automatic Retries Trigger Policy"
+  body = file("${path.module}/policies/trigger-retries.rego")
+}
+
 # Define the global "git push" policy that causes executions on stacks when `<component_root>/*.tf` is modified
 resource "spacelift_policy" "push" {
   type = "GIT_PUSH"

--- a/main.tf
+++ b/main.tf
@@ -43,8 +43,9 @@ module "spacelift_environment" {
 
 # Define the global trigger policy that allows us to trigger on various context-level updates
 resource "spacelift_policy" "trigger_global" {
-  type = "TRIGGER"
+  count = var.trigger_global_enabled ? 1 : 0
 
+  type = "TRIGGER"
   name = "Global Trigger Policy"
   body = file("${path.module}/policies/trigger-global.rego")
 }
@@ -52,23 +53,22 @@ resource "spacelift_policy" "trigger_global" {
 # Define the dependency trigger policy that allows us to define custom triggers
 resource "spacelift_policy" "trigger_dependency" {
   type = "TRIGGER"
-
   name = "Stack Dependency Trigger Policy"
   body = file("${path.module}/policies/trigger-dependencies.rego")
 }
 
 # Define the automatic retries trigger policy that allows automatically restarting the failed run
-# resource "spacelift_policy" "trigger_retries" {
-#   type = "TRIGGER"
-#
-#  name = "Failed Run Automatic Retries Trigger Policy"
-#  body = file("${path.module}/policies/trigger-retries.rego")
-#}
+resource "spacelift_policy" "trigger_retries" {
+  count = var.trigger_retries_enabled ? 1 : 0
+
+  type = "TRIGGER"
+  name = "Failed Run Automatic Retries Trigger Policy"
+  body = file("${path.module}/policies/trigger-retries.rego")
+}
 
 # Define the global "git push" policy that causes executions on stacks when `<component_root>/*.tf` is modified
 resource "spacelift_policy" "push" {
   type = "GIT_PUSH"
-
   name = "Global Push Policy"
   body = file("${path.module}/policies/push-global.rego")
 }
@@ -76,7 +76,6 @@ resource "spacelift_policy" "push" {
 # Define a global "plan" policy that stops and waits for confirmation after a plan fails
 resource "spacelift_policy" "plan" {
   type = "PLAN"
-
   name = "Global Plan Policy"
   body = file("${path.module}/policies/plan-global.rego")
 }

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -18,6 +18,7 @@ module "stacks" {
   manage_state         = var.manage_state
   component_vars       = { for k, v in try(each.value.vars, {}) : k => jsonencode(v) }
   component_stack_deps = try(each.value.stacks, [])
+  imports              = var.imports
   terraform_version    = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), try(each.value.settings.spacelift.terraform_version, var.terraform_version))
   terraform_workspace  = each.value.workspace
   worker_pool_id       = var.worker_pool_id

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -6,23 +6,24 @@ module "stacks" {
     format("%s-%s", var.stack_config_name, k) => merge({ "component_name" : k }, v)
   }
 
-  enabled             = try(each.value.settings.spacelift.workspace_enabled, false)
-  stack_name          = each.key
-  stack_config_name   = var.stack_config_name
-  logical_component   = each.value.component_name
-  component_name      = coalesce(each.value.component, each.value.component_name)
-  autodeploy          = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
-  component_root      = format("%s/%s", var.components_path, coalesce(each.value.component, each.value.component_name))
-  repository          = var.repository
-  branch              = coalesce(try(each.value.settings.spacelift.branch, null), var.branch)
-  manage_state        = var.manage_state
-  component_vars      = { for k, v in try(each.value.vars, {}) : k => jsonencode(v) }
-  terraform_version   = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), try(each.value.settings.spacelift.terraform_version, var.terraform_version))
-  terraform_workspace = each.value.workspace
-  worker_pool_id      = var.worker_pool_id
-  runner_image        = try(var.runner_image, null)
-  triggers            = coalesce(try(each.value.settings.spacelift.triggers, null), [])
-  trigger_policy_id   = var.trigger_policy_id
-  push_policy_id      = var.push_policy_id
-  plan_policy_id      = var.plan_policy_id
+  enabled              = try(each.value.settings.spacelift.workspace_enabled, false)
+  stack_name           = each.key
+  stack_config_name    = var.stack_config_name
+  logical_component    = each.value.component_name
+  component_name       = coalesce(each.value.component, each.value.component_name)
+  autodeploy           = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
+  component_root       = format("%s/%s", var.components_path, coalesce(each.value.component, each.value.component_name))
+  repository           = var.repository
+  branch               = coalesce(try(each.value.settings.spacelift.branch, null), var.branch)
+  manage_state         = var.manage_state
+  component_vars       = { for k, v in try(each.value.vars, {}) : k => jsonencode(v) }
+  component_stack_deps = try(each.value.stacks, [])
+  terraform_version    = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), try(each.value.settings.spacelift.terraform_version, var.terraform_version))
+  terraform_workspace  = each.value.workspace
+  worker_pool_id       = var.worker_pool_id
+  runner_image         = try(var.runner_image, null)
+  triggers             = coalesce(try(each.value.settings.spacelift.triggers, null), [])
+  trigger_policy_id    = var.trigger_policy_id
+  push_policy_id       = var.push_policy_id
+  plan_policy_id       = var.plan_policy_id
 }

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -6,26 +6,27 @@ module "stacks" {
     format("%s-%s", var.stack_config_name, k) => merge({ "component_name" : k }, v)
   }
 
-  enabled              = try(each.value.settings.spacelift.workspace_enabled, false)
-  stack_name           = each.key
-  stack_config_name    = var.stack_config_name
-  logical_component    = each.value.component_name
-  component_name       = coalesce(each.value.component, each.value.component_name)
-  autodeploy           = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
-  component_root       = format("%s/%s", var.components_path, coalesce(each.value.component, each.value.component_name))
-  repository           = var.repository
-  branch               = coalesce(try(each.value.settings.spacelift.branch, null), var.branch)
-  manage_state         = var.manage_state
-  component_vars       = { for k, v in try(each.value.vars, {}) : k => jsonencode(v) }
-  component_stack_deps = try(each.value.stacks, [])
-  imports              = var.imports
-  stack_config_path    = var.stack_config_path
-  terraform_version    = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), try(each.value.settings.spacelift.terraform_version, var.terraform_version))
-  terraform_workspace  = each.value.workspace
-  worker_pool_id       = var.worker_pool_id
-  runner_image         = try(var.runner_image, null)
-  triggers             = coalesce(try(each.value.settings.spacelift.triggers, null), [])
-  trigger_policy_id    = var.trigger_policy_id
-  push_policy_id       = var.push_policy_id
-  plan_policy_id       = var.plan_policy_id
+  enabled                      = try(each.value.settings.spacelift.workspace_enabled, false)
+  stack_name                   = each.key
+  stack_config_name            = var.stack_config_name
+  logical_component            = each.value.component_name
+  component_name               = coalesce(each.value.component, each.value.component_name)
+  autodeploy                   = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
+  component_root               = format("%s/%s", var.components_path, coalesce(each.value.component, each.value.component_name))
+  repository                   = var.repository
+  branch                       = coalesce(try(each.value.settings.spacelift.branch, null), var.branch)
+  manage_state                 = var.manage_state
+  component_vars               = { for k, v in try(each.value.vars, {}) : k => jsonencode(v) }
+  component_stack_deps         = try(each.value.stacks, [])
+  imports                      = var.imports
+  stack_config_path            = var.stack_config_path
+  terraform_version            = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), try(each.value.settings.spacelift.terraform_version, var.terraform_version))
+  terraform_workspace          = each.value.workspace
+  worker_pool_id               = var.worker_pool_id
+  runner_image                 = try(var.runner_image, null)
+  triggers                     = coalesce(try(each.value.settings.spacelift.triggers, null), [])
+  trigger_policy_id            = var.trigger_policy_id
+  push_policy_id               = var.push_policy_id
+  plan_policy_id               = var.plan_policy_id
+  process_component_stack_deps = var.process_component_stack_deps
 }

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -19,6 +19,7 @@ module "stacks" {
   component_vars       = { for k, v in try(each.value.vars, {}) : k => jsonencode(v) }
   component_stack_deps = try(each.value.stacks, [])
   imports              = var.imports
+  stack_config_path    = var.stack_config_path
   terraform_version    = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), try(each.value.settings.spacelift.terraform_version, var.terraform_version))
   terraform_workspace  = each.value.workspace
   worker_pool_id       = var.worker_pool_id

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -91,3 +91,9 @@ variable "autodeploy" {
   description = "Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration)"
   default     = null
 }
+
+variable "process_component_stack_deps" {
+  type        = bool
+  description = "Enable/disable processing stack dependencies for components"
+  default     = false
+}

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -5,8 +5,8 @@ variable "stack_config_name" {
 
 variable "stack_config_path" {
   type        = string
-  default     = "stack"
-  description = "The name of the configuration directory to use in the trigger prefix."
+  default     = "stacks"
+  description = "Relative path to YAML config files"
 }
 
 variable "trigger_policy_id" {

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -33,6 +33,12 @@ variable "components" {
   description = "A map of all components and related configurations that exist within the environment."
 }
 
+variable "imports" {
+  type        = list(string)
+  default     = []
+  description = "A list of stack imports."
+}
+
 variable "components_path" {
   default     = "components"
   type        = string

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -3,7 +3,7 @@ locals {
 
   imports = [for import in var.imports : "import:${import}"]
 
-  component_stack_deps = [for dep in var.component_stack_deps : "stack-deps:${dep}" if var.process_component_stack_deps == true]
+  component_stack_deps = [for dep in var.component_stack_deps : format("stack-deps:%s/%s.yaml", var.stack_config_path, dep) if var.process_component_stack_deps == true]
 
   stack_config_name_parts = split("-", var.stack_config_name)
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -3,6 +3,7 @@ locals {
 
   labels = {
     triggers   = local.triggers
+    imports    = var.imports
     stack_deps = var.component_stack_deps
   }
 }

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -13,12 +13,12 @@ locals {
     try(format("folder:component/%s", var.logical_component), "")
   ]
 
-  labels = compact(concat(
+  labels = distinct(compact(concat(
     local.triggers,
     local.imports,
     local.component_stack_deps,
     local.folders
-  ))
+  )))
 }
 
 resource "spacelift_stack" "default" {

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -1,3 +1,12 @@
+locals {
+  triggers = [for trigger in var.triggers : "depends-on:${trigger}|state:FINISHED"]
+
+  labels = {
+    triggers = local.triggers
+    stacks   = var.component_stack_deps
+  }
+}
+
 resource "spacelift_stack" "default" {
   count = var.enabled ? 1 : 0
 
@@ -8,9 +17,7 @@ resource "spacelift_stack" "default" {
   branch         = var.branch
   project_root   = var.component_root
   manage_state   = var.manage_state
-  labels = [
-    for trigger in var.triggers : "depends-on:${trigger}|state:FINISHED"
-  ]
+  labels         = [jsonencode(local.labels)]
 
   worker_pool_id      = var.worker_pool_id
   runner_image        = var.runner_image

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -2,8 +2,8 @@ locals {
   triggers = [for trigger in var.triggers : "depends-on:${trigger}|state:FINISHED"]
 
   labels = {
-    triggers = local.triggers
-    stacks   = var.component_stack_deps
+    triggers   = local.triggers
+    stack_deps = var.component_stack_deps
   }
 }
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -77,6 +77,12 @@ variable "component_vars" {
   description = "All Terraform values to be applied to the stack via a mounted file."
 }
 
+variable "component_stack_deps" {
+  type        = list(string)
+  default     = []
+  description = "A list of component stack dependencies."
+}
+
 variable "triggers" {
   type        = list(any)
   default     = []

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -60,6 +60,12 @@ variable "stack_config_name" {
   description = "The name of the stack configuration (Atmos stack name)"
 }
 
+variable "stack_config_path" {
+  type        = string
+  default     = "stacks"
+  description = "Relative path to YAML config files"
+}
+
 variable "component_name" {
   type        = string
   description = "The name of the concrete component (typically a directory name)"

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -129,3 +129,9 @@ variable "manage_state" {
   description = "Flag to enable/disable manage_state setting in stack"
   default     = true
 }
+
+variable "process_component_stack_deps" {
+  type        = bool
+  description = "Enable/disable processing stack dependencies for components"
+  default     = false
+}

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -70,7 +70,6 @@ variable "logical_component" {
   description = "The name of the component (may be an alternate instance of a concrete component)"
 }
 
-
 variable "component_vars" {
   type        = map(any)
   default     = {}
@@ -81,6 +80,12 @@ variable "component_stack_deps" {
   type        = list(string)
   default     = []
   description = "A list of component stack dependencies."
+}
+
+variable "imports" {
+  type        = list(string)
+  default     = []
+  description = "A list of stack imports."
 }
 
 variable "triggers" {

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -1,45 +1,42 @@
 # https://docs.spacelift.io/concepts/policy/git-push-policy
-# https://www.openpolicyagent.org/docs/latest/policy-language/#variable-keys
-# https://www.openpolicyagent.org/docs/latest/policy-reference/#iteration
 
 package spacelift
 
-# Track if Terraform files are affected
+# Ignore if any of the `ignore` rules evaluates to `true`
+ignore  {
+    not project_affected
+    not stack_config_affected
+}
+
+ignore {
+    input.push.tag != ""
+}
+
+# If pre-commit hooks make changes, they are not semantic changes and can and should be ignored
+ignore  {
+    input.push.message == "pre-commit fixes"
+}
+
+# Only trigger a stack run if the project files were modified
+notrigger {
+    stack_config_affected
+    not project_affected
+}
+
+propose {
+    project_affected
+}
+
+# Track if project files are affected
 track {
-    tf_affected
+    project_affected
     input.push.branch == input.stack.branch
 }
 
 # Track if stack config files are affected
 track {
-    config_affected
+    stack_config_affected
     input.push.branch == input.stack.branch
-}
-
-# Only trigger a stack run if the Terraform files were modified
-notrigger {
-    config_affected
-    not tf_affected
-}
-
-propose { 
-    tf_affected 
-}
-
-# Ignore if any of the `ignore` rules evaluate to `true`
-ignore  {
-    not tf_affected
-    not config_affected
-}
-
-ignore  { 
-    input.push.tag != "" 
-}
-
-# If pre-commit hooks make changes, they are not semantic changes
-# and can and should be ignored.
-ignore  { 
-    input.push.message == "pre-commit fixes" 
 }
 
 # Get all of the affected files
@@ -48,27 +45,34 @@ affected_files := input.push.affected_files
 # Track these extensions in the project folder
 tracked_extensions := {".tf", ".tf.json", ".tfvars", ".yaml"}
 
+project_root := input.stack.project_root
+
 # Check if any of the tracked extensions were modified in the project folder
-tf_affected {
-    startswith(affected_files[_], input.stack.project_root)
-    endswith(affected_files[_], tracked_extensions[_])
+# https://www.openpolicyagent.org/docs/latest/policy-language/#some-keyword
+# https://www.openpolicyagent.org/docs/latest/policy-language/#variable-keys
+# https://www.openpolicyagent.org/docs/latest/policy-reference/#iteration
+project_affected {
+    some i, j
+    startswith(affected_files[i], project_root)
+    endswith(affected_files[i], tracked_extensions[j])
 }
 
-# Get stack dependencies and imports from the provided `labels`
-label := input.stack.labels[0]
-config := json.unmarshal(label)
-stack_deps := config.stack_deps
-imports := config.imports
+# Get labels
+labels := input.stack.labels
+
+# Get imports from the provided `labels`
+# https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions
+imports := [imp | startswith(labels[i], "import:"); imp := split(labels[i], ":")[1]]
 
 # Split the stack name into a list
-stack_name := split(input.stack.name, "-")
+stack_name_parts := split(input.stack.name, "-")
 
 # Check if the environment has been modified
-config_affected {
-    contains(affected_files[_], concat("-", [stack_name[0], stack_name[1]]))
+stack_config_affected {
+    contains(affected_files[_], concat("-", [stack_name_parts[0], stack_name_parts[1]]))
 }
 
 # Check if any of the imports have been modified
-config_affected {
+stack_config_affected {
     endswith(affected_files[_], imports[_])
 }

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -18,10 +18,10 @@ ignore  {
 }
 
 # Only trigger a stack run if the project files were modified
-notrigger {
-    stack_config_affected
-    not project_affected
-}
+# notrigger {
+#    stack_config_affected
+#   not project_affected
+#}
 
 propose {
     project_affected

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -1,3 +1,5 @@
+# https://docs.spacelift.io/concepts/policy/git-push-policy
+
 package spacelift
 
 # Update tracking for affected Terraform files
@@ -14,15 +16,18 @@ track {
 
 # Only trigger a stack run if the Terraform files were modified
 notrigger {
-  config_affected
-  not tf_affected
+    config_affected
+    not tf_affected
 }
 
 propose { tf_affected }
+
+# Ignore if any of the `ignore` rules evaluate to `true`
 ignore  {
     not tf_affected
     not config_affected
 }
+
 ignore  { input.push.tag != "" }
 
 # If pre-commit hooks make changes, they are not semantic changes
@@ -30,46 +35,51 @@ ignore  { input.push.tag != "" }
 ignore  { input.push.message == "pre-commit fixes" }
 
 # Fetch all of our affected files
-filepath := input.push.affected_files
+affected_files := input.push.affected_files
 
 # Check if any Terraform files were modified in a project
 tf_affected {
-    startswith(filepath[_], input.stack.project_root)
-    endswith(filepath[_], ".tf")
+    startswith(affected_files[_], input.stack.project_root)
+    endswith(affected_files[_], ".tf")
 }
 
 # Check if any Terraform json files were modified in a project
 tf_affected {
-    startswith(filepath[_], input.stack.project_root)
-    endswith(filepath[_], ".tf.json")
+    startswith(affected_files[_], input.stack.project_root)
+    endswith(affected_files[_], ".tf.json")
 }
 
 # Check if any .tfvars files were modified in a project
 tf_affected {
-    startswith(filepath[_], input.stack.project_root)
-    endswith(filepath[_], ".tfvars")
+    startswith(affected_files[_], input.stack.project_root)
+    endswith(affected_files[_], ".tfvars")
 }
 
 # Check if any .yaml files were modified in a project
 tf_affected {
-    startswith(filepath[_], input.stack.project_root)
-    endswith(filepath[_], ".yaml")
+    startswith(affected_files[_], input.stack.project_root)
+    endswith(affected_files[_], ".yaml")
 }
+
+# Get stack-related config from `labels`
+label := input.stack.labels[0]
+config := json.unmarshal(label)
+stack_deps := config.stack_deps
 
 # Split our stack name into a list for matching below
 stack_name := split(input.stack.name, "-")
 
 # Check if our global settings have been modified
 config_affected {
-    contains(filepath[_], "/globals.yaml")
+    contains(affected_files[_], "/globals.yaml")
 }
 
 # Check if our environment globals have been modified
 config_affected {
-    contains(filepath[_], concat("-", [stack_name[0], "globals"]))
+    contains(affected_files[_], concat("-", [stack_name[0], "globals"]))
 }
 
 # Check if our environment has been modified
 config_affected {
-    contains(filepath[_], concat("-", [stack_name[0], stack_name[1]]))
+    contains(affected_files[_], concat("-", [stack_name[0], stack_name[1]]))
 }

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -72,6 +72,8 @@ stack_config_affected {
 }
 
 # Get component stack dependencies from the provided `labels`
+# NOTE: component stack dependencies are disabled in the module (var.process_component_stack_deps == false),
+# and the below rules will not be evaluated by default
 stack_deps := [dep | startswith(labels[i], "stack-deps:"); dep := split(labels[i], ":")[1]]
 
 # Check if any of the stack dependencies have been modified

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -61,10 +61,12 @@ tf_affected {
     endswith(affected_files[_], ".yaml")
 }
 
-# Get stack-related config from `labels`
+# Get stack-related configs from `labels`
 label := input.stack.labels[0]
 config := json.unmarshal(label)
 stack_deps := config.stack_deps
+imports := config.imports
+
 
 # Split our stack name into a list for matching below
 stack_name := split(input.stack.name, "-")

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -1,14 +1,16 @@
 # https://docs.spacelift.io/concepts/policy/git-push-policy
+# https://www.openpolicyagent.org/docs/latest/policy-language/#variable-keys
+# https://www.openpolicyagent.org/docs/latest/policy-reference/#iteration
 
 package spacelift
 
-# Update tracking for affected Terraform files
+# Track if Terraform files are affected
 track {
     tf_affected
     input.push.branch == input.stack.branch
 }
 
-# Update tracking for affected stack config files
+# Track if stack config files are affected
 track {
     config_affected
     input.push.branch == input.stack.branch
@@ -20,7 +22,9 @@ notrigger {
     not tf_affected
 }
 
-propose { tf_affected }
+propose { 
+    tf_affected 
+}
 
 # Ignore if any of the `ignore` rules evaluate to `true`
 ignore  {
@@ -28,60 +32,43 @@ ignore  {
     not config_affected
 }
 
-ignore  { input.push.tag != "" }
+ignore  { 
+    input.push.tag != "" 
+}
 
 # If pre-commit hooks make changes, they are not semantic changes
 # and can and should be ignored.
-ignore  { input.push.message == "pre-commit fixes" }
+ignore  { 
+    input.push.message == "pre-commit fixes" 
+}
 
-# Fetch all of our affected files
+# Get all of the affected files
 affected_files := input.push.affected_files
 
-# Check if any Terraform files were modified in a project
+# Track these extensions in the project folder
+tracked_extensions := {".tf", ".tf.json", ".tfvars", ".yaml"}
+
+# Check if any of the tracked extensions were modified in the project folder
 tf_affected {
     startswith(affected_files[_], input.stack.project_root)
-    endswith(affected_files[_], ".tf")
+    endswith(affected_files[_], tracked_extensions[_])
 }
 
-# Check if any Terraform json files were modified in a project
-tf_affected {
-    startswith(affected_files[_], input.stack.project_root)
-    endswith(affected_files[_], ".tf.json")
-}
-
-# Check if any .tfvars files were modified in a project
-tf_affected {
-    startswith(affected_files[_], input.stack.project_root)
-    endswith(affected_files[_], ".tfvars")
-}
-
-# Check if any .yaml files were modified in a project
-tf_affected {
-    startswith(affected_files[_], input.stack.project_root)
-    endswith(affected_files[_], ".yaml")
-}
-
-# Get stack-related configs from `labels`
+# Get stack dependencies and imports from the provided `labels`
 label := input.stack.labels[0]
 config := json.unmarshal(label)
 stack_deps := config.stack_deps
 imports := config.imports
 
-
-# Split our stack name into a list for matching below
+# Split the stack name into a list
 stack_name := split(input.stack.name, "-")
 
-# Check if our global settings have been modified
-config_affected {
-    contains(affected_files[_], "/globals.yaml")
-}
-
-# Check if our environment globals have been modified
-config_affected {
-    contains(affected_files[_], concat("-", [stack_name[0], "globals"]))
-}
-
-# Check if our environment has been modified
+# Check if the environment has been modified
 config_affected {
     contains(affected_files[_], concat("-", [stack_name[0], stack_name[1]]))
+}
+
+# Check if any of the imports have been modified
+config_affected {
+    endswith(affected_files[_], imports[_])
 }

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -17,12 +17,6 @@ ignore  {
     input.push.message == "pre-commit fixes"
 }
 
-# Only trigger a stack run if the project files were modified
-# notrigger {
-#    stack_config_affected
-#   not project_affected
-#}
-
 propose {
     project_affected
 }

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -57,13 +57,6 @@ project_affected {
     endswith(affected_files[i], tracked_extensions[j])
 }
 
-# Get labels
-labels := input.stack.labels
-
-# Get imports from the provided `labels`
-# https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions
-imports := [imp | startswith(labels[i], "import:"); imp := split(labels[i], ":")[1]]
-
 # Split the stack name into a list
 stack_name_parts := split(input.stack.name, "-")
 
@@ -72,7 +65,22 @@ stack_config_affected {
     contains(affected_files[_], concat("-", [stack_name_parts[0], stack_name_parts[1]]))
 }
 
+# Get labels
+labels := input.stack.labels
+
+# Get imports from the provided `labels`
+# https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions
+imports := [imp | startswith(labels[i], "import:"); imp := split(labels[i], ":")[1]]
+
 # Check if any of the imports have been modified
 stack_config_affected {
     endswith(affected_files[_], imports[_])
+}
+
+# Get component stack dependencies from the provided `labels`
+stack_deps := [dep | startswith(labels[i], "stack-deps:"); dep := split(labels[i], ":")[1]]
+
+# Check if any of the stack dependencies have been modified
+stack_config_affected {
+    endswith(affected_files[_], stack_deps[_])
 }

--- a/policies/trigger-dependencies.rego
+++ b/policies/trigger-dependencies.rego
@@ -9,6 +9,6 @@ trigger[stack.id] {
   input.run.state == "FINISHED"
   stack.labels[_] == concat("", [
     "depends-on:", input.stack.id,
-    "|state:", input.run.state],
+    "|state:", input.run.state]
   )
 }

--- a/policies/trigger-global.rego
+++ b/policies/trigger-global.rego
@@ -3,7 +3,7 @@ package spacelift
 trigger[stack.id] {
   stack := input.stacks[_]
   entity := input.run.changes[_].entity
-  
+
   input.run.state == "FINISHED"
   contains(entity.address, concat("", ["stacks[\"", stack.name, "\"].spacelift_mounted_file."]))
 }

--- a/policies/trigger-retries.rego
+++ b/policies/trigger-retries.rego
@@ -11,5 +11,5 @@ trigger[stack.id] {
   is_null(input.run.triggered_by)
 }
 
-# Note that this policy will also prevent user-triggered runs from being retried
-# Which is usually what you want in the first place, because a triggering human is probably already babysitting the Stack anyway
+# Note that this policy will also prevent user-triggered runs from being retried.
+# Which is usually what you want in the first place, because a triggering human is probably already babysitting the Stack anyway.

--- a/policies/trigger-retries.rego
+++ b/policies/trigger-retries.rego
@@ -1,0 +1,15 @@
+package spacelift
+
+# You can read more about trigger policies here:
+#
+# https://docs.spacelift.io/concepts/policy/trigger-policy
+
+trigger[stack.id] {
+  stack := input.stack
+  input.run.state == "FAILED"
+  input.run.type == "TRACKED"
+  is_null(input.run.triggered_by)
+}
+
+# Note that this policy will also prevent user-triggered runs from being retried
+# Which is usually what you want in the first place, because a triggering human is probably already babysitting the Stack anyway

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,9 @@ variable "trigger_global_enabled" {
   description = "Flag to enable/disable the global trigger"
   default     = false
 }
+
+variable "process_component_stack_deps" {
+  type        = bool
+  description = "Enable/disable processing stack dependencies for components"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "stack_config_path" {
   type        = string
   description = "Relative path to YAML config files"
-  default     = null
+  default     = "stacks"
 }
 
 variable "stack_config_files" {

--- a/variables.tf
+++ b/variables.tf
@@ -68,3 +68,15 @@ variable "autodeploy" {
   description = "Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration)"
   default     = false
 }
+
+variable "trigger_retries_enabled" {
+  type        = bool
+  description = "Flag to enable/disable the automatic retries trigger"
+  default     = false
+}
+
+variable "trigger_global_enabled" {
+  type        = bool
+  description = "Flag to enable/disable the global trigger"
+  default     = false
+}


### PR DESCRIPTION
## what
* Add support for Spacelift folders
* Implement Spacelift triggers policy per component based on stack configs & imports
* Add support for Spacelift automated retries

## why
* Automatically add folder labels for affected environment, stage and component
* When we open a PR that modifies any YAML config file, it doesn’t trigger the stacks. We need each Spacelift stack to have a push policy for each stack configuration file that triggers the stack when any of the YAML config files (including any imports) are modified
* When not properly configured to keep AWS IAM credentials fresh, Spacelift frequently encounters RPC failures in the apply phase. Retry refreshes the credentials and works. We now support automating the retry in the module using the Automatic Retries Rego policy

## test
* https://play.openpolicyagent.org/p/6IBeVLCtcb

<br>

![image](https://user-images.githubusercontent.com/7356997/115947839-7469b100-a498-11eb-8008-0e5f38ce6cc2.png)

