### PR TITLE
Add `stack_config_folder_name` variable

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -46,7 +46,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/---\s+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Available targets:
 | <a name="input_repository"></a> [repository](#input\_repository) | The name of your infrastructure repo | `string` | n/a | yes |
 | <a name="input_runner_image"></a> [runner\_image](#input\_runner\_image) | The full image name and tag of the Docker image to use in Spacelift | `string` | `null` | no |
 | <a name="input_stack_config_files"></a> [stack\_config\_files](#input\_stack\_config\_files) | A list of stack config files | `list(any)` | `[]` | no |
+| <a name="input_stack_config_folder_name"></a> [stack\_config\_folder\_name](#input\_stack\_config\_folder\_name) | The name of the folder with YAML config files | `string` | `"stacks"` | no |
 | <a name="input_stack_config_path"></a> [stack\_config\_path](#input\_stack\_config\_path) | Relative path to YAML config files | `string` | `"stacks"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -67,6 +67,7 @@
 | <a name="input_repository"></a> [repository](#input\_repository) | The name of your infrastructure repo | `string` | n/a | yes |
 | <a name="input_runner_image"></a> [runner\_image](#input\_runner\_image) | The full image name and tag of the Docker image to use in Spacelift | `string` | `null` | no |
 | <a name="input_stack_config_files"></a> [stack\_config\_files](#input\_stack\_config\_files) | A list of stack config files | `list(any)` | `[]` | no |
+| <a name="input_stack_config_folder_name"></a> [stack\_config\_folder\_name](#input\_stack\_config\_folder\_name) | The name of the folder with YAML config files | `string` | `"stacks"` | no |
 | <a name="input_stack_config_path"></a> [stack\_config\_path](#input\_stack\_config\_path) | Relative path to YAML config files | `string` | `"stacks"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,21 +22,22 @@ module "spacelift_environment" {
 
   for_each = toset(var.stack_config_files)
 
-  trigger_policy_id = join("", spacelift_policy.trigger_global.*.id)
-  push_policy_id    = spacelift_policy.push.id
-  plan_policy_id    = spacelift_policy.plan.id
-  stack_config_name = trimsuffix(each.key, ".yaml")
-  components        = try(module.yaml_stack_config[each.key].config.0.components.terraform, {})
-  imports           = [for import in try(module.yaml_stack_config[each.key].config.0.imports, []) : format("%s/%s.yaml", local.stack_config_path, import)]
-  components_path   = var.components_path
-  stack_config_path = local.stack_config_path
-  repository        = var.repository
-  branch            = var.branch
-  manage_state      = var.manage_state
-  worker_pool_id    = var.worker_pool_id
-  runner_image      = var.runner_image
-  terraform_version = var.terraform_version
-  autodeploy        = var.autodeploy
+  trigger_policy_id        = join("", spacelift_policy.trigger_global.*.id)
+  push_policy_id           = spacelift_policy.push.id
+  plan_policy_id           = spacelift_policy.plan.id
+  stack_config_name        = trimsuffix(each.key, ".yaml")
+  components               = try(module.yaml_stack_config[each.key].config.0.components.terraform, {})
+  imports                  = [for import in try(module.yaml_stack_config[each.key].config.0.imports, []) : format("%s/%s.yaml", var.stack_config_folder_name, import)]
+  components_path          = var.components_path
+  stack_config_path        = local.stack_config_path
+  stack_config_folder_name = var.stack_config_folder_name
+  repository               = var.repository
+  branch                   = var.branch
+  manage_state             = var.manage_state
+  worker_pool_id           = var.worker_pool_id
+  runner_image             = var.runner_image
+  terraform_version        = var.terraform_version
+  autodeploy               = var.autodeploy
 
   terraform_version_map        = var.terraform_version_map
   process_component_stack_deps = var.process_component_stack_deps

--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -20,6 +20,7 @@ module "stacks" {
   component_stack_deps         = try(each.value.stacks, [])
   imports                      = var.imports
   stack_config_path            = var.stack_config_path
+  stack_config_folder_name     = var.stack_config_folder_name
   terraform_version            = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), try(each.value.settings.spacelift.terraform_version, var.terraform_version))
   terraform_workspace          = each.value.workspace
   worker_pool_id               = var.worker_pool_id

--- a/modules/environment/variables.tf
+++ b/modules/environment/variables.tf
@@ -9,6 +9,12 @@ variable "stack_config_path" {
   description = "Relative path to YAML config files"
 }
 
+variable "stack_config_folder_name" {
+  type        = string
+  description = "The name of the folder with YAML config files"
+  default     = "stacks"
+}
+
 variable "trigger_policy_id" {
   type        = string
   default     = null

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -3,7 +3,7 @@ locals {
 
   imports = [for import in var.imports : "import:${import}"]
 
-  component_stack_deps = [for dep in var.component_stack_deps : format("stack-deps:%s/%s.yaml", var.stack_config_path, dep) if var.process_component_stack_deps == true]
+  component_stack_deps = [for dep in var.component_stack_deps : format("stack-deps:%s/%s.yaml", var.stack_config_folder_name, dep) if var.process_component_stack_deps == true]
 
   stack_config_name_parts = split("-", var.stack_config_name)
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -66,6 +66,12 @@ variable "stack_config_path" {
   description = "Relative path to YAML config files"
 }
 
+variable "stack_config_folder_name" {
+  type        = string
+  description = "The name of the folder with YAML config files"
+  default     = "stacks"
+}
+
 variable "component_name" {
   type        = string
   description = "The name of the concrete component (typically a directory name)"

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "stack_config_path" {
   default     = "stacks"
 }
 
+variable "stack_config_folder_name" {
+  type        = string
+  description = "The name of the folder with YAML config files"
+  default     = "stacks"
+}
+
 variable "stack_config_files" {
   type        = list(any)
   description = "A list of stack config files"


### PR DESCRIPTION
## what
* Add `stack_config_folder_name` variable

## why
* The existing variable `stack_config_path` is used to read the YAML stack config using the `terraform-yaml-stack-config` module, and it needs to be a relative path to the `stacks` folder at the time of execution so the module could find the YAML config files. It's usually in the format `../../../stacks`
* On the other hand, we need to specify the name of the stack config folder to prefix the imports with it to be used in the Rego policies (it should not be a relative path to stack configs)


