### PR TITLE
Update `trigger-global` policy. Add component ENV vars to Spacelift stack ENV vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "stacks" {
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component
   component_vars            = each.value.vars
+  component_env             = each.value.env
   terraform_workspace       = each.value.workspace
   labels                    = each.value.labels
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -1,3 +1,7 @@
+locals {
+  component_env = { for k, v in var.component_env : k => v if var.enabled == true }
+}
+
 resource "spacelift_stack" "default" {
   count = var.enabled ? 1 : 0
 
@@ -40,6 +44,15 @@ resource "spacelift_environment_variable" "component_name" {
   stack_id   = spacelift_stack.default[0].id
   name       = "ATMOS_COMPONENT"
   value      = var.component_name
+  write_only = false
+}
+
+resource "spacelift_environment_variable" "component_env_vars" {
+  for_each = local.component_env
+
+  stack_id   = spacelift_stack.default[0].id
+  name       = each.key
+  value      = each.value
   write_only = false
 }
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -65,6 +65,12 @@ variable "component_vars" {
   description = "All Terraform values to be applied to the stack via a mounted file"
 }
 
+variable "component_env" {
+  type        = any
+  default     = {}
+  description = "Map of component ENV variables"
+}
+
 variable "trigger_policy_id" {
   type        = string
   default     = null

--- a/policies/trigger-global.rego
+++ b/policies/trigger-global.rego
@@ -2,8 +2,13 @@ package spacelift
 
 trigger[stack.id] {
   stack := input.stacks[_]
-  entity := input.run.changes[_].entity
+  # compare a plaintext string (stack.id) to a checksum
+  endswith(crypto.sha256(stack.id), id_shas_of_created_stacks[_])
+}
 
-  input.run.state == "FINISHED"
-  contains(entity.address, concat("", ["stacks[\"", stack.name, "\"].spacelift_mounted_file."]))
+id_shas_of_created_stacks[change.entity.data.values.id] {
+  change := input.run.changes[_]
+  change.action == "added"
+  change.entity.type == "spacelift_stack"
+  change.phase == "apply" # The change has actually been applied, not just planned
 }


### PR DESCRIPTION
## what
* Update `trigger-global` policy
* Add component ENV vars to Spacelift stack ENV vars

## why
* The updated `trigger-global` policy will trigger Spacelift stack deployment after it gets created (when `spacelift/workspace_enabled` set to `true` in the same PR that adds the stack config itself)

* YAML stack configs support the `env` section for each component, which is a map of ENV vars

```
env:
  ENV_TEST_1: value1
  TF_CLI_ARGS_apply: "-parallelism=1"
```

This will allow setting Terraform parameters (e.g. `-parallelism`) for each infrastructure component individually.

