### PR TITLE
Update `trigger-dependencies` Rego policy and attach it to all Spacelift stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 1.0.0 |
+| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.0.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 1.0.0 |
+| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.0.4 |
 
 ## Modules
 
@@ -214,22 +214,14 @@ Available targets:
 
 | Name | Type |
 |------|------|
-
-| spacelift_policy.plan | resource |
-
-| spacelift_policy.push | resource |
-
-| spacelift_policy.trigger_dependency | resource |
-
-| spacelift_policy.trigger_global | resource |
-
-| spacelift_policy.trigger_retries | resource |
-
-| spacelift_policy_attachment.trigger_global | resource |
-
-| spacelift_policy_attachment.trigger_retries | resource |
-
-| spacelift_current_stack.this | data source |
+| [spacelift_policy.plan](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy.push](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy.trigger_dependency](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy.trigger_global](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy.trigger_retries](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy_attachment.trigger_global](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy_attachment) | resource |
+| [spacelift_policy_attachment.trigger_retries](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy_attachment) | resource |
+| [spacelift_current_stack.this](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/data-sources/current_stack) | data source |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 1.0.0 |
+| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.0.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 1.0.0 |
+| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.0.4 |
 
 ## Modules
 
@@ -24,22 +24,14 @@
 
 | Name | Type |
 |------|------|
-
-| spacelift_policy.plan | resource |
-
-| spacelift_policy.push | resource |
-
-| spacelift_policy.trigger_dependency | resource |
-
-| spacelift_policy.trigger_global | resource |
-
-| spacelift_policy.trigger_retries | resource |
-
-| spacelift_policy_attachment.trigger_global | resource |
-
-| spacelift_policy_attachment.trigger_retries | resource |
-
-| spacelift_current_stack.this | data source |
+| [spacelift_policy.plan](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy.push](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy.trigger_dependency](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy.trigger_global](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy.trigger_retries](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
+| [spacelift_policy_attachment.trigger_global](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy_attachment) | resource |
+| [spacelift_policy_attachment.trigger_retries](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy_attachment) | resource |
+| [spacelift_current_stack.this](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/data-sources/current_stack) | data source |
 
 ## Inputs
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -69,3 +69,10 @@ resource "spacelift_policy_attachment" "plan" {
   policy_id = var.plan_policy_id
   stack_id  = spacelift_stack.default[0].id
 }
+
+resource "spacelift_policy_attachment" "trigger_dependency" {
+  count = var.enabled ? 1 : 0
+
+  policy_id = var.trigger_policy_id
+  stack_id  = spacelift_stack.default[0].id
+}

--- a/modules/stack/versions.tf
+++ b/modules/stack/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     spacelift = {
-      source  = "spacelift.io/spacelift-io/spacelift"
-      version = ">= 1.0.0"
+      source  = "spacelift-io/spacelift"
+      version = ">= 0.0.4"
     }
   }
 }

--- a/policies/trigger-dependencies.rego
+++ b/policies/trigger-dependencies.rego
@@ -4,11 +4,11 @@ package spacelift
 #
 # https://docs.spacelift.io/concepts/policy/trigger-policy
 
-trigger[stack.id] {
-  stack := input.stacks[_]
+# Trigger other stacks (from `input.stacks` list) that depend on the current stack (`input.stack.id`)
+# The other stacks must have a label `depends-on:<current_stack_name>` to be triggered after the current stack finishes running
+trigger[other_stack.id] {
+  other_stack := input.stacks[_]
   input.run.state == "FINISHED"
-  stack.labels[_] == concat("", [
-    "depends-on:", input.stack.id,
-    "|state:", input.run.state]
-  )
+  input.run.type == "TRACKED"
+  other_stack.labels[_] == concat("", ["depends-on:", input.stack.id])
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     spacelift = {
-      source  = "spacelift.io/spacelift-io/spacelift"
-      version = ">= 1.0.0"
+      source  = "spacelift-io/spacelift"
+      version = ">= 0.0.4"
     }
   }
 }


### PR DESCRIPTION
## what
* Update `trigger-dependencies` Rego policy and attach it to all Spacelift stacks
* Update Spacelift terraform provider source and version

## why
* The updated `trigger-dependencies` Rego policy is attached to all infrastructure stacks and will trigger other infrasctructure stacks that depend on the current stack. The other stacks must have a label `depends-on:<current_stack_name>` to be triggered after the current stack finishes running

* Labels `depends-on:<current_stack_name>` are defined in YAML stack config files and attached to each Spacelift stack by `terraform-provider-utils` (see *references*) 

* Will be used in Spacelift workflows to trigger the dependent stacks after the "parent" stacks finish running

* Update Spacelift terraform provider source and version to use the official provider from the Terraform registry

## references
* https://github.com/cloudposse/terraform-provider-utils/pull/43
* https://registry.terraform.io/providers/spacelift-io/spacelift/latest

