### PR TITLE
Add `spacelift_webhook` to each stack. Allow enabling/disabling webhooks per stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ Available targets:
 | <a name="input_terraform_version_map"></a> [terraform\_version\_map](#input\_terraform\_version\_map) | A map to determine which Terraform patch version to use for each minor version | `map(string)` | `{}` | no |
 | <a name="input_trigger_global_enabled"></a> [trigger\_global\_enabled](#input\_trigger\_global\_enabled) | Flag to enable/disable the global trigger | `bool` | `false` | no |
 | <a name="input_trigger_retries_enabled"></a> [trigger\_retries\_enabled](#input\_trigger\_retries\_enabled) | Flag to enable/disable the automatic retries trigger | `bool` | `false` | no |
+| <a name="input_webhook_enabled"></a> [webhook\_enabled](#input\_webhook\_enabled) | Flag to enable/disable the webhook endpoint to which Spacelift sends the POST requests about run state changes | `bool` | `false` | no |
+| <a name="input_webhook_endpoint"></a> [webhook\_endpoint](#input\_webhook\_endpoint) | Webhook endpoint to which Spacelift sends the POST requests about run state changes | `string` | `null` | no |
+| <a name="input_webhook_secret"></a> [webhook\_secret](#input\_webhook\_secret) | Webhook secret used to sign each POST request so you're able to verify that the requests come from Spacelift | `string` | `null` | no |
 | <a name="input_worker_pool_id"></a> [worker\_pool\_id](#input\_worker\_pool\_id) | The immutable ID (slug) of the worker pool | `string` | `null` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -69,6 +69,9 @@
 | <a name="input_terraform_version_map"></a> [terraform\_version\_map](#input\_terraform\_version\_map) | A map to determine which Terraform patch version to use for each minor version | `map(string)` | `{}` | no |
 | <a name="input_trigger_global_enabled"></a> [trigger\_global\_enabled](#input\_trigger\_global\_enabled) | Flag to enable/disable the global trigger | `bool` | `false` | no |
 | <a name="input_trigger_retries_enabled"></a> [trigger\_retries\_enabled](#input\_trigger\_retries\_enabled) | Flag to enable/disable the automatic retries trigger | `bool` | `false` | no |
+| <a name="input_webhook_enabled"></a> [webhook\_enabled](#input\_webhook\_enabled) | Flag to enable/disable the webhook endpoint to which Spacelift sends the POST requests about run state changes | `bool` | `false` | no |
+| <a name="input_webhook_endpoint"></a> [webhook\_endpoint](#input\_webhook\_endpoint) | Webhook endpoint to which Spacelift sends the POST requests about run state changes | `string` | `null` | no |
+| <a name="input_webhook_secret"></a> [webhook\_secret](#input\_webhook\_secret) | Webhook secret used to sign each POST request so you're able to verify that the requests come from Spacelift | `string` | `null` | no |
 | <a name="input_worker_pool_id"></a> [worker\_pool\_id](#input\_worker\_pool\_id) | The immutable ID (slug) of the worker pool | `string` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,10 @@ module "stacks" {
   push_policy_id    = spacelift_policy.push.id
   plan_policy_id    = spacelift_policy.plan.id
   trigger_policy_id = spacelift_policy.trigger_dependency.id
+
+  webhook_enabled  = try(each.value.settings.spacelift.webhook_enabled, null) != null ? each.value.settings.spacelift.webhook_enabled : var.webhook_enabled
+  webhook_endpoint = coalesce(try(each.value.settings.spacelift.webhook_endpoint, null), var.webhook_endpoint)
+  webhook_secret   = var.webhook_secret
 }
 
 # Define the global "git push" policy that causes executions on stacks when `<component_root>/*.tf` is modified

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -79,7 +79,6 @@ resource "spacelift_policy_attachment" "trigger_dependency" {
 
 resource "spacelift_webhook" "default" {
   enabled  = var.enabled && var.webhook_enabled
-  id       = format("%s-webhook", var.stack_name)
   stack_id = spacelift_stack.default[0].id
   endpoint = var.webhook_endpoint
   secret   = var.webhook_secret

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -76,3 +76,11 @@ resource "spacelift_policy_attachment" "trigger_dependency" {
   policy_id = var.trigger_policy_id
   stack_id  = spacelift_stack.default[0].id
 }
+
+resource "spacelift_webhook" "default" {
+  enabled  = var.enabled && var.webhook_enabled
+  id       = format("%s-webhook", var.stack_name)
+  stack_id = spacelift_stack.default[0].id
+  endpoint = var.webhook_endpoint
+  secret   = var.webhook_secret
+}

--- a/modules/stack/outputs.tf
+++ b/modules/stack/outputs.tf
@@ -1,5 +1,6 @@
 output "config" {
   description = "A map of stack configurations"
+
   value = try({
     id                = spacelift_stack.default[0].id
     name              = spacelift_stack.default[0].name
@@ -8,5 +9,6 @@ output "config" {
     worker_pool_id    = spacelift_stack.default[0].worker_pool_id
     repository        = spacelift_stack.default[0].repository
     branch            = spacelift_stack.default[0].branch
+    webhook_id        = join("", spacelift_webhook.default.*.id)
   }, "disabled")
 }

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -106,3 +106,21 @@ variable "labels" {
   description = "A list of labels for the stack"
   default     = []
 }
+
+variable "webhook_enabled" {
+  type        = bool
+  description = "Flag to enable/disable the webhook endpoint to which Spacelift sends the POST requests about run state changes"
+  default     = false
+}
+
+variable "webhook_endpoint" {
+  type        = string
+  description = "Webhook endpoint to which Spacelift sends the POST requests about run state changes"
+  default     = null
+}
+
+variable "webhook_secret" {
+  type        = string
+  description = "Webhook secret used to sign each POST request so you're able to verify that the requests come from Spacelift"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -103,3 +103,21 @@ variable "trigger_global_enabled" {
   description = "Flag to enable/disable the global trigger"
   default     = false
 }
+
+variable "webhook_enabled" {
+  type        = bool
+  description = "Flag to enable/disable the webhook endpoint to which Spacelift sends the POST requests about run state changes"
+  default     = false
+}
+
+variable "webhook_endpoint" {
+  type        = string
+  description = "Webhook endpoint to which Spacelift sends the POST requests about run state changes"
+  default     = null
+}
+
+variable "webhook_secret" {
+  type        = string
+  description = "Webhook secret used to sign each POST request so you're able to verify that the requests come from Spacelift"
+  default     = null
+}


### PR DESCRIPTION
## what
* Add `spacelift_webhook` to each Spacelift stack
* Allow enabling/disabling webhooks per stack in YAML config files

## why
* Allow integration between Spacelift and third-party event-collection systems (e.g. Splunk) to monitor and audit Spacelift runs
* Spacelift sends POST requests about run state changes to the webhook endpoint  

## references
* https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/webhook
* https://github.com/spacelift-io/terraform-provider-spacelift#spacelift_webhook-resource

