### PR TITLE
Fix `spacelift_webhook`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ module "stacks" {
   trigger_policy_id = spacelift_policy.trigger_dependency.id
 
   webhook_enabled  = try(each.value.settings.spacelift.webhook_enabled, null) != null ? each.value.settings.spacelift.webhook_enabled : var.webhook_enabled
-  webhook_endpoint = coalesce(try(each.value.settings.spacelift.webhook_endpoint, null), var.webhook_endpoint)
+  webhook_endpoint = try(each.value.settings.spacelift.webhook_endpoint, null) != null ? each.value.settings.spacelift.webhook_endpoint : var.webhook_endpoint
   webhook_secret   = var.webhook_secret
 }
 


### PR DESCRIPTION
## what
* Fix `spacelift_webhook`

## why
* `webhook_endpoint` is optional
* If `webhook_endpoint` is not defined in YAML config nor in `var.webhook_endpoint`, `coalesce` is not working and the following error gets thrown:

```
 webhook_endpoint = coalesce(try(each.value.settings.spacelift.webhook_endpoint, null), var.webhook_endpoint)
    |----------------
    | each.value.settings.spacelift is object with 1 attribute "workspace_enabled"
    | var.webhook_endpoint is null

Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

