### PR TITLE
use `count` instead of `enabled` in `resource "spacelift_webhook"`

### DIFF
--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -78,7 +78,8 @@ resource "spacelift_policy_attachment" "trigger_dependency" {
 }
 
 resource "spacelift_webhook" "default" {
-  enabled  = var.enabled && var.webhook_enabled
+  count = var.enabled && var.webhook_enabled
+
   stack_id = spacelift_stack.default[0].id
   endpoint = var.webhook_endpoint
   secret   = var.webhook_secret

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -78,7 +78,7 @@ resource "spacelift_policy_attachment" "trigger_dependency" {
 }
 
 resource "spacelift_webhook" "default" {
-  count = var.enabled && var.webhook_enabled
+  count = var.enabled && var.webhook_enabled ? 1 : 0
 
   stack_id = spacelift_stack.default[0].id
   endpoint = var.webhook_endpoint


### PR DESCRIPTION
## what
* use `count` instead of `enabled` in `resource "spacelift_webhook"`

## why
* Even if `enabled` is set to `false` , the Spacelift provider still looks at the `endpoint` and complains if it's not provided 



