### PR TITLE
feat: adds .yml to push-global tracked_extensions to support both yamls

### DIFF
--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -89,5 +89,6 @@ deps := [dep | startswith(labels[i], "deps:"); dep := split(labels[i], ":")[1]]
 
 # Check if any of the stack dependencies have been modified
 stack_config_affected {
+    startswith(affected_files[_], deps[_])
     endswith(affected_files[_], deps[_])
 }

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -89,6 +89,10 @@ deps := [dep | startswith(labels[i], "deps:"); dep := split(labels[i], ":")[1]]
 
 # Check if any of the stack dependencies have been modified
 stack_config_affected {
-    startswith(affected_files[_], deps[_])
     endswith(affected_files[_], deps[_])
+}
+
+# Checking startswith allows `deps:*` to reference top level folders.
+stack_config_affected {
+    startswith(affected_files[_], deps[_])
 }

--- a/policies/push-global.rego
+++ b/policies/push-global.rego
@@ -37,7 +37,7 @@ track {
 affected_files := input.push.affected_files
 
 # Track these extensions in the project folder
-tracked_extensions := {".tf", ".tf.json", ".tfvars", ".yaml", ".tpl", ".sh"}
+tracked_extensions := {".tf", ".tf.json", ".tfvars", ".yaml", ".yml", ".tpl", ".sh"}
 
 project_root := input.stack.project_root
 


### PR DESCRIPTION
## what
* Adds `.yml` to tracked extensions in the global push policy. 
* Adds `startswith(affected_files[_], deps[_])` to `stack_config_affected`


## why
* Enables support for both yaml file extensions: `yml` + `yaml`
* Allows `deps` labels to be a directory such as `deps:config/` or `deps:lambda_src/` and still get picked up as a change

## references
* N/A

