### PR TITLE
Enable custom external Rego policies per Spacelift stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Available targets:
 
 | Name | Type |
 |------|------|
+| [spacelift_policy.custom](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy.default](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy.trigger_administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy_attachment.trigger_administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy_attachment) | resource |
@@ -247,7 +248,8 @@ Available targets:
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_plan_policy_id"></a> [plan\_policy\_id](#input\_plan\_policy\_id) | ID of an existing Plan policy to override the default | `string` | `null` | no |
 | <a name="input_policies_available"></a> [policies\_available](#input\_policies\_available) | List of available default policies to create in Spacelift (these policies will not be attached to Spacelift stacks by default, use `var.policies_enabled`) | `list(string)` | <pre>[<br>  "access.default",<br>  "git_push.default",<br>  "plan.default",<br>  "trigger.dependencies",<br>  "trigger.retries"<br>]</pre> | no |
-| <a name="input_policies_by_id_enabled"></a> [policies\_by\_id\_enabled](#input\_policies\_by\_id\_enabled) | List of existing policy IDs to attach to all Spacelift stacks | `list(string)` | `[]` | no |
+| <a name="input_policies_by_id_enabled"></a> [policies\_by\_id\_enabled](#input\_policies\_by\_id\_enabled) | List of existing policy IDs to attach to all Spacelift stacks. These policies must be created outside of this module | `list(string)` | `[]` | no |
+| <a name="input_policies_by_name_path"></a> [policies\_by\_name\_path](#input\_policies\_by\_name\_path) | Path to the catalog of external Rego policies. The Rego files must exist in the caller's code at the path. The module will create Spacelift policies from the external Rego definitions | `string` | `""` | no |
 | <a name="input_policies_enabled"></a> [policies\_enabled](#input\_policies\_enabled) | List of default policies to attach to all Spacelift stacks | `list(string)` | <pre>[<br>  "git_push.default",<br>  "plan.default",<br>  "trigger.dependencies"<br>]</pre> | no |
 | <a name="input_policies_path"></a> [policies\_path](#input\_policies\_path) | Path to the catalog of default policies | `string` | `"catalog/policies"` | no |
 | <a name="input_push_policy_id"></a> [push\_policy\_id](#input\_push\_policy\_id) | ID of an existing Push policy to override the default | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,6 +24,7 @@
 
 | Name | Type |
 |------|------|
+| [spacelift_policy.custom](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy.default](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy.trigger_administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy_attachment.trigger_administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy_attachment) | resource |
@@ -57,7 +58,8 @@
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_plan_policy_id"></a> [plan\_policy\_id](#input\_plan\_policy\_id) | ID of an existing Plan policy to override the default | `string` | `null` | no |
 | <a name="input_policies_available"></a> [policies\_available](#input\_policies\_available) | List of available default policies to create in Spacelift (these policies will not be attached to Spacelift stacks by default, use `var.policies_enabled`) | `list(string)` | <pre>[<br>  "access.default",<br>  "git_push.default",<br>  "plan.default",<br>  "trigger.dependencies",<br>  "trigger.retries"<br>]</pre> | no |
-| <a name="input_policies_by_id_enabled"></a> [policies\_by\_id\_enabled](#input\_policies\_by\_id\_enabled) | List of existing policy IDs to attach to all Spacelift stacks | `list(string)` | `[]` | no |
+| <a name="input_policies_by_id_enabled"></a> [policies\_by\_id\_enabled](#input\_policies\_by\_id\_enabled) | List of existing policy IDs to attach to all Spacelift stacks. These policies must be created outside of this module | `list(string)` | `[]` | no |
+| <a name="input_policies_by_name_path"></a> [policies\_by\_name\_path](#input\_policies\_by\_name\_path) | Path to the catalog of external Rego policies. The Rego files must exist in the caller's code at the path. The module will create Spacelift policies from the external Rego definitions | `string` | `""` | no |
 | <a name="input_policies_enabled"></a> [policies\_enabled](#input\_policies\_enabled) | List of default policies to attach to all Spacelift stacks | `list(string)` | <pre>[<br>  "git_push.default",<br>  "plan.default",<br>  "trigger.dependencies"<br>]</pre> | no |
 | <a name="input_policies_path"></a> [policies\_path](#input\_policies\_path) | Path to the catalog of default policies | `string` | `"catalog/policies"` | no |
 | <a name="input_push_policy_id"></a> [push\_policy\_id](#input\_push\_policy\_id) | ID of an existing Push policy to override the default | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -69,8 +69,8 @@ module "stacks" {
 
   # Policies to attach to the stack (internally created + additional external provided by IDs + additional external created by this module from external Rego files)
   policy_ids = concat(
-    compact([for i in try(each.value.settings.spacelift.policies_enabled, var.policies_enabled) : spacelift_policy.default[i].id]),
-    compact([for i in try(each.value.settings.spacelift.policies_by_name_enabled, []) : spacelift_policy.custom[i].id]),
+    [for i in try(each.value.settings.spacelift.policies_enabled, var.policies_enabled) : spacelift_policy.default[i].id],
+    [for i in try(each.value.settings.spacelift.policies_by_name_enabled, []) : spacelift_policy.custom[i].id],
     var.policies_by_id_enabled
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -182,6 +182,12 @@ variable "policies_path" {
 
 variable "policies_by_id_enabled" {
   type        = list(string)
-  description = "List of existing policy IDs to attach to all Spacelift stacks"
+  description = "List of existing policy IDs to attach to all Spacelift stacks. These policies must be created outside of this module"
   default     = []
+}
+
+variable "policies_by_name_path" {
+  type        = string
+  description = "Path to the catalog of external Rego policies. The Rego files must exist in the caller's code at the path. The module will create Spacelift policies from the external Rego definitions"
+  default     = ""
 }


### PR DESCRIPTION
## what
* Enable custom external Rego policies per Spacelift stack
* Allow specifying custom Rego policies by names in YAML stack configs

## why
* The callers of the module can define their own `catalog` of various custom Rego policies and use them to attach to different stacks
* For example, the caller might have a set of custom Rego `ACCESS` policies (with different names, e.g. `access.dms-prod.rego`, `access.dms-dev.rego`) to allow only particular teams/users to access specific Spacelift stacks to provision specific resources

