### PR TITLE
Add `spacelift_stack_destructor` and `spacelift_aws_role` resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.0.4 |
+| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.0.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.0.4 |
+| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.0.5 |
 
 ## Modules
 
@@ -233,6 +233,10 @@ Available targets:
 | <a name="input_administrative_trigger_policy_enabled"></a> [administrative\_trigger\_policy\_enabled](#input\_administrative\_trigger\_policy\_enabled) | Flag to enable/disable the global administrative trigger policy | `bool` | `true` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | <a name="input_autodeploy"></a> [autodeploy](#input\_autodeploy) | Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration) | `bool` | `false` | no |
+| <a name="input_aws_role_arn"></a> [aws\_role\_arn](#input\_aws\_role\_arn) | ARN of the AWS IAM role to assume and put its temporary credentials in the runtime environment | `string` | `null` | no |
+| <a name="input_aws_role_enabled"></a> [aws\_role\_enabled](#input\_aws\_role\_enabled) | Flag to enable/disable Spacelift to use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment | `bool` | `false` | no |
+| <a name="input_aws_role_external_id"></a> [aws\_role\_external\_id](#input\_aws\_role\_external\_id) | Custom external ID (works only for private workers). See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html for more details | `string` | `null` | no |
+| <a name="input_aws_role_generate_credentials_in_worker"></a> [aws\_role\_generate\_credentials\_in\_worker](#input\_aws\_role\_generate\_credentials\_in\_worker) | Flag to enable/disable generating AWS credentials in the private worker after assuming the supplied IAM role | `bool` | `true` | no |
 | <a name="input_branch"></a> [branch](#input\_branch) | Specify which branch to use within your infrastructure repo | `string` | `"main"` | no |
 | <a name="input_component_deps_processing_enabled"></a> [component\_deps\_processing\_enabled](#input\_component\_deps\_processing\_enabled) | Boolean flag to enable/disable processing stack config dependencies for the components in the provided stack | `bool` | `true` | no |
 | <a name="input_components_path"></a> [components\_path](#input\_components\_path) | The relative pathname for where all components reside | `string` | `"components"` | no |
@@ -266,6 +270,7 @@ Available targets:
 | <a name="input_stack_config_path"></a> [stack\_config\_path](#input\_stack\_config\_path) | Relative path to YAML config files | `string` | `"./stacks"` | no |
 | <a name="input_stack_config_path_template"></a> [stack\_config\_path\_template](#input\_stack\_config\_path\_template) | Stack config path template | `string` | `"stacks/%s.yaml"` | no |
 | <a name="input_stack_deps_processing_enabled"></a> [stack\_deps\_processing\_enabled](#input\_stack\_deps\_processing\_enabled) | Boolean flag to enable/disable processing all stack dependencies in the provided stack | `bool` | `false` | no |
+| <a name="input_stack_destructor_enabled"></a> [stack\_destructor\_enabled](#input\_stack\_destructor\_enabled) | Flag to enable/disable the stack destructor to destroy the resources of a stack before deleting the stack itself | `bool` | `false` | no |
 | <a name="input_stacks"></a> [stacks](#input\_stacks) | A list of stack configs | `list(any)` | n/a | yes |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.0.4 |
+| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.0.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.0.4 |
+| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.0.5 |
 
 ## Modules
 
@@ -43,6 +43,10 @@
 | <a name="input_administrative_trigger_policy_enabled"></a> [administrative\_trigger\_policy\_enabled](#input\_administrative\_trigger\_policy\_enabled) | Flag to enable/disable the global administrative trigger policy | `bool` | `true` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | <a name="input_autodeploy"></a> [autodeploy](#input\_autodeploy) | Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration) | `bool` | `false` | no |
+| <a name="input_aws_role_arn"></a> [aws\_role\_arn](#input\_aws\_role\_arn) | ARN of the AWS IAM role to assume and put its temporary credentials in the runtime environment | `string` | `null` | no |
+| <a name="input_aws_role_enabled"></a> [aws\_role\_enabled](#input\_aws\_role\_enabled) | Flag to enable/disable Spacelift to use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment | `bool` | `false` | no |
+| <a name="input_aws_role_external_id"></a> [aws\_role\_external\_id](#input\_aws\_role\_external\_id) | Custom external ID (works only for private workers). See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html for more details | `string` | `null` | no |
+| <a name="input_aws_role_generate_credentials_in_worker"></a> [aws\_role\_generate\_credentials\_in\_worker](#input\_aws\_role\_generate\_credentials\_in\_worker) | Flag to enable/disable generating AWS credentials in the private worker after assuming the supplied IAM role | `bool` | `true` | no |
 | <a name="input_branch"></a> [branch](#input\_branch) | Specify which branch to use within your infrastructure repo | `string` | `"main"` | no |
 | <a name="input_component_deps_processing_enabled"></a> [component\_deps\_processing\_enabled](#input\_component\_deps\_processing\_enabled) | Boolean flag to enable/disable processing stack config dependencies for the components in the provided stack | `bool` | `true` | no |
 | <a name="input_components_path"></a> [components\_path](#input\_components\_path) | The relative pathname for where all components reside | `string` | `"components"` | no |
@@ -76,6 +80,7 @@
 | <a name="input_stack_config_path"></a> [stack\_config\_path](#input\_stack\_config\_path) | Relative path to YAML config files | `string` | `"./stacks"` | no |
 | <a name="input_stack_config_path_template"></a> [stack\_config\_path\_template](#input\_stack\_config\_path\_template) | Stack config path template | `string` | `"stacks/%s.yaml"` | no |
 | <a name="input_stack_deps_processing_enabled"></a> [stack\_deps\_processing\_enabled](#input\_stack\_deps\_processing\_enabled) | Boolean flag to enable/disable processing all stack dependencies in the provided stack | `bool` | `false` | no |
+| <a name="input_stack_destructor_enabled"></a> [stack\_destructor\_enabled](#input\_stack\_destructor\_enabled) | Flag to enable/disable the stack destructor to destroy the resources of a stack before deleting the stack itself | `bool` | `false` | no |
 | <a name="input_stacks"></a> [stacks](#input\_stacks) | A list of stack configs | `list(any)` | n/a | yes |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     spacelift = {
       source  = "spacelift-io/spacelift"
-      version = ">= 0.0.4"
+      version = ">= 0.0.5"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,16 @@ module "stacks" {
   drift_detection_enabled   = try(each.value.settings.spacelift.drift_detection_enabled, null) != null ? each.value.settings.spacelift.drift_detection_enabled : var.drift_detection_enabled
   drift_detection_reconcile = try(each.value.settings.spacelift.drift_detection_reconcile, null) != null ? each.value.settings.spacelift.drift_detection_reconcile : var.drift_detection_reconcile
   drift_detection_schedule  = try(each.value.settings.spacelift.drift_detection_schedule, null) != null ? each.value.settings.spacelift.drift_detection_schedule : var.drift_detection_schedule
+
+  aws_role_enabled     = try(each.value.settings.spacelift.aws_role_enabled, null) != null ? each.value.settings.spacelift.aws_role_enabled : var.aws_role_enabled
+  aws_role_arn         = try(each.value.settings.spacelift.aws_role_arn, null) != null ? each.value.settings.spacelift.aws_role_arn : var.aws_role_arn
+  aws_role_external_id = try(each.value.settings.spacelift.aws_role_external_id, null) != null ? each.value.settings.spacelift.aws_role_external_id : var.aws_role_external_id
+
+  aws_role_generate_credentials_in_worker = try(each.value.settings.spacelift.aws_role_generate_credentials_in_worker, null) != null ? (
+    each.value.settings.spacelift.aws_role_generate_credentials_in_worker
+  ) : var.aws_role_generate_credentials_in_worker
+
+  stack_destructor_enabled = try(each.value.settings.spacelift.stack_destructor_enabled, null) != null ? each.value.settings.spacelift.stack_destructor_enabled : var.stack_destructor_enabled
 }
 
 # `administrative` policies are always attached to the `administrative` stack

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -81,3 +81,27 @@ resource "spacelift_drift_detection" "default" {
   reconcile = var.drift_detection_reconcile
   schedule  = var.drift_detection_schedule
 }
+
+resource "spacelift_aws_role" "default" {
+  count = var.enabled && var.aws_role_enabled ? 1 : 0
+
+  stack_id                       = spacelift_stack.default[0].id
+  role_arn                       = var.aws_role_arn
+  external_id                    = var.aws_role_external_id
+  generate_credentials_in_worker = var.aws_role_generate_credentials_in_worker
+}
+
+resource "spacelift_stack_destructor" "default" {
+  count = var.enabled && var.stack_destructor_enabled ? 1 : 0
+
+  stack_id = spacelift_stack.default[0].id
+
+  depends_on = [
+    spacelift_mounted_file.stack_config,
+    spacelift_environment_variable.stack_name,
+    spacelift_environment_variable.component_name,
+    spacelift_environment_variable.component_env_vars,
+    spacelift_policy_attachment.default,
+    spacelift_aws_role.default
+  ]
+}

--- a/modules/stack/outputs.tf
+++ b/modules/stack/outputs.tf
@@ -2,13 +2,15 @@ output "config" {
   description = "A map of stack configurations"
 
   value = try({
-    id                = spacelift_stack.default[0].id
-    name              = spacelift_stack.default[0].name
-    autodeploy        = spacelift_stack.default[0].autodeploy
-    terraform_version = spacelift_stack.default[0].terraform_version
-    worker_pool_id    = spacelift_stack.default[0].worker_pool_id
-    repository        = spacelift_stack.default[0].repository
-    branch            = spacelift_stack.default[0].branch
-    webhook_id        = join("", spacelift_webhook.default.*.id)
+    id                  = spacelift_stack.default[0].id
+    name                = spacelift_stack.default[0].name
+    autodeploy          = spacelift_stack.default[0].autodeploy
+    terraform_version   = spacelift_stack.default[0].terraform_version
+    worker_pool_id      = spacelift_stack.default[0].worker_pool_id
+    repository          = spacelift_stack.default[0].repository
+    branch              = spacelift_stack.default[0].branch
+    webhook_id          = join("", spacelift_webhook.default.*.id)
+    aws_role_id         = join("", spacelift_aws_role.default.*.id)
+    stack_destructor_id = join("", spacelift_stack_destructor.default.*.id)
   }, "disabled")
 }

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -136,3 +136,33 @@ variable "drift_detection_schedule" {
   description = "List of cron expressions to schedule drift detection for the infrastructure stacks"
   default     = ["0 */24 * * *"]
 }
+
+variable "aws_role_enabled" {
+  type        = bool
+  description = "Flag to enable/disable Spacelift to use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment"
+  default     = false
+}
+
+variable "aws_role_arn" {
+  type        = string
+  description = "ARN of the AWS IAM role to assume and put its temporary credentials in the runtime environment"
+  default     = null
+}
+
+variable "aws_role_external_id" {
+  type        = string
+  description = "Custom external ID (works only for private workers). See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html for more details"
+  default     = null
+}
+
+variable "aws_role_generate_credentials_in_worker" {
+  type        = bool
+  description = "Flag to enable/disable generating AWS credentials in the private worker after assuming the supplied IAM role"
+  default     = true
+}
+
+variable "stack_destructor_enabled" {
+  type        = bool
+  description = "Flag to enable/disable the stack destructor to destroy the resources of the stack before deleting the stack itself"
+  default     = false
+}

--- a/modules/stack/versions.tf
+++ b/modules/stack/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     spacelift = {
       source  = "spacelift-io/spacelift"
-      version = ">= 0.0.4"
+      version = ">= 0.0.5"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -227,3 +227,33 @@ variable "drift_detection_schedule" {
   description = "List of cron expressions to schedule drift detection for the infrastructure stacks"
   default     = ["0 */24 * * *"]
 }
+
+variable "aws_role_enabled" {
+  type        = bool
+  description = "Flag to enable/disable Spacelift to use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment"
+  default     = false
+}
+
+variable "aws_role_arn" {
+  type        = string
+  description = "ARN of the AWS IAM role to assume and put its temporary credentials in the runtime environment"
+  default     = null
+}
+
+variable "aws_role_external_id" {
+  type        = string
+  description = "Custom external ID (works only for private workers). See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html for more details"
+  default     = null
+}
+
+variable "aws_role_generate_credentials_in_worker" {
+  type        = bool
+  description = "Flag to enable/disable generating AWS credentials in the private worker after assuming the supplied IAM role"
+  default     = true
+}
+
+variable "stack_destructor_enabled" {
+  type        = bool
+  description = "Flag to enable/disable the stack destructor to destroy the resources of a stack before deleting the stack itself"
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     spacelift = {
       source  = "spacelift-io/spacelift"
-      version = ">= 0.0.4"
+      version = ">= 0.0.5"
     }
   }
 }


### PR DESCRIPTION
## what
* Add `spacelift_stack_destructor` and `spacelift_aws_role` resources

## why
* `spacelift_stack_destructor` enables destroying the resources of a stack before deleting the stack itself (configurable per stack in YAML config)
* `spacelift_aws_role` represents cross-account IAM role delegation between the Spacelift worker and an individual stack. If this is enabled, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment (configurable per stack in YAML config)

## references
* https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack_destructor 
* https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/aws_role

