### PR TITLE
Fix Git Push policies. Remove `ignore` block from the Git Push policies 

### DIFF
--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -19,11 +19,6 @@ project_root := input.stack.project_root
 proposed_run_pull_request_actions := {"opened", "reopened", "synchronize"}
 
 # Ignore if any of the `ignore` rules evaluates to `true`
-ignore  {
-    not project_affected
-    not stack_config_affected
-}
-
 # If pre-commit hooks make changes, they are not semantic changes and can and should be ignored
 ignore  {
     input.push.message == "pre-commit fixes"

--- a/catalog/policies/git_push.tracked-run.rego
+++ b/catalog/policies/git_push.tracked-run.rego
@@ -14,17 +14,6 @@ tracked_extensions := {".tf", ".tf.json", ".tfvars", ".yaml", ".yml", ".tpl", ".
 # Project root
 project_root := input.stack.project_root
 
-# Ignore if any of the `ignore` rules evaluates to `true`
-ignore  {
-    not project_affected
-    not stack_config_affected
-}
-
-# If pre-commit hooks make changes, they are not semantic changes and can and should be ignored
-ignore  {
-    input.push.message == "pre-commit fixes"
-}
-
 # Track if project files are affected and the push was to the stack's tracked branch
 # https://docs.spacelift.io/concepts/run/tracked
 track {


### PR DESCRIPTION
## what
* Fix Git push policies
* Remove `ignore` block from the Git Push policies 

## why
* We already provide `propose` and `track` block which have all the required logic to evaluate if a proposed a tracked run needs to be started
* The `ignore` block is redundant in the policies, since it uses the same (but opposite) logic as the `propose` and `track `block
* Having the `ignore` block in the two Git Push policies prevents a run from being triggered in some cases (e.g. when pushing directly to the default/tracked branch, the `ignore` block in the `git_push.propose-run.rego` policy prevents the traked run from being triggered in the `git_push.tracked-run.rego` policy

```
The policy may define boolean track, propose and ignore rules. 
The positive outcome of at least one ignore rule causes the push to be ignored, 
no matter the outcome of other rules. 
The positive outcome of at least one track rule triggers a tracked run. 
The positive outcome of at least one propose rule triggers a proposed run.
```

## references
* https://docs.spacelift.io/concepts/policy/git-push-policy

