### PR TITLE
Remove `coalesce` from `commit_sha` argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ module "stacks" {
   autodeploy            = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
   branch                = coalesce(try(each.value.settings.spacelift.branch, null), var.branch)
   repository            = coalesce(try(each.value.settings.spacelift.repository, null), var.repository)
-  commit_sha            = coalesce(try(each.value.settings.spacelift.commit_sha, null), var.commit_sha)
+  commit_sha            = var.commit_sha != null ? var.commit_sha : try(each.value.settings.spacelift.commit_sha, null)
   spacelift_run_enabled = coalesce(try(each.value.settings.spacelift.spacelift_run_enabled, null), var.spacelift_run_enabled)
   terraform_version     = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), var.terraform_version)
   component_root        = coalesce(try(each.value.settings.spacelift.component_root, null), format("%s/%s", var.components_path, coalesce(each.value.base_component, each.value.component)))


### PR DESCRIPTION
## what
* Remove `coalesce` from `commit_sha` argument

## why
Both arguments are either null or empty which causes the error:

```
│ Error: Error in function call
│ 
│   on .terraform/modules/spacelift/main.tf line 58, in module "stacks":
│   58:   commit_sha            = coalesce(try(each.value.settings.spacelift.commit_sha, null), var.commit_sha)
│     ├────────────────
│     │ each.value.settings.spacelift is object with 1 attribute "workspace_enabled"
│     │ var.commit_sha is null
│ 
│ Call to function "coalesce" failed: no non-null, non-empty-string
│ arguments.
```

https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/blob/7a306ca1d80fd3cc32fb0db9e53b9ded16e73012/main.tf#L58

The fix is to remove the `coalesce` statement.

## references
* Previous PR https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/pull/55

