### PR TITLE
Add administrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| <a name="input_administrative"></a> [administrative](#input\_administrative) | Whether this stack can manage others | `bool` | `false` | no |
+| <a name="input_administrative"></a> [administrative](#input\_administrative) | Whether this stack can manage other stacks | `bool` | `false` | no |
 | <a name="input_administrative_stack_drift_detection_enabled"></a> [administrative\_stack\_drift\_detection\_enabled](#input\_administrative\_stack\_drift\_detection\_enabled) | Flag to enable/disable administrative stack drift detection | `bool` | `true` | no |
 | <a name="input_administrative_stack_drift_detection_reconcile"></a> [administrative\_stack\_drift\_detection\_reconcile](#input\_administrative\_stack\_drift\_detection\_reconcile) | Flag to enable/disable administrative stack drift automatic reconciliation. If drift is detected and `reconcile` is turned on, Spacelift will create a tracked run to correct the drift | `bool` | `true` | no |
 | <a name="input_administrative_stack_drift_detection_schedule"></a> [administrative\_stack\_drift\_detection\_schedule](#input\_administrative\_stack\_drift\_detection\_schedule) | List of cron expressions to schedule drift detection for the administrative stack | `list(string)` | <pre>[<br>  "0 4 * * *"<br>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_administrative"></a> [administrative](#input\_administrative) | Whether this stack can manage others | `bool` | `false` | no |
 | <a name="input_administrative_stack_drift_detection_enabled"></a> [administrative\_stack\_drift\_detection\_enabled](#input\_administrative\_stack\_drift\_detection\_enabled) | Flag to enable/disable administrative stack drift detection | `bool` | `true` | no |
 | <a name="input_administrative_stack_drift_detection_reconcile"></a> [administrative\_stack\_drift\_detection\_reconcile](#input\_administrative\_stack\_drift\_detection\_reconcile) | Flag to enable/disable administrative stack drift automatic reconciliation. If drift is detected and `reconcile` is turned on, Spacelift will create a tracked run to correct the drift | `bool` | `true` | no |
 | <a name="input_administrative_stack_drift_detection_schedule"></a> [administrative\_stack\_drift\_detection\_schedule](#input\_administrative\_stack\_drift\_detection\_schedule) | List of cron expressions to schedule drift detection for the administrative stack | `list(string)` | <pre>[<br>  "0 4 * * *"<br>]</pre> | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -36,7 +36,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| <a name="input_administrative"></a> [administrative](#input\_administrative) | Whether this stack can manage others | `bool` | `false` | no |
+| <a name="input_administrative"></a> [administrative](#input\_administrative) | Whether this stack can manage other stacks | `bool` | `false` | no |
 | <a name="input_administrative_stack_drift_detection_enabled"></a> [administrative\_stack\_drift\_detection\_enabled](#input\_administrative\_stack\_drift\_detection\_enabled) | Flag to enable/disable administrative stack drift detection | `bool` | `true` | no |
 | <a name="input_administrative_stack_drift_detection_reconcile"></a> [administrative\_stack\_drift\_detection\_reconcile](#input\_administrative\_stack\_drift\_detection\_reconcile) | Flag to enable/disable administrative stack drift automatic reconciliation. If drift is detected and `reconcile` is turned on, Spacelift will create a tracked run to correct the drift | `bool` | `true` | no |
 | <a name="input_administrative_stack_drift_detection_schedule"></a> [administrative\_stack\_drift\_detection\_schedule](#input\_administrative\_stack\_drift\_detection\_schedule) | List of cron expressions to schedule drift detection for the administrative stack | `list(string)` | <pre>[<br>  "0 4 * * *"<br>]</pre> | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -36,6 +36,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_administrative"></a> [administrative](#input\_administrative) | Whether this stack can manage others | `bool` | `false` | no |
 | <a name="input_administrative_stack_drift_detection_enabled"></a> [administrative\_stack\_drift\_detection\_enabled](#input\_administrative\_stack\_drift\_detection\_enabled) | Flag to enable/disable administrative stack drift detection | `bool` | `true` | no |
 | <a name="input_administrative_stack_drift_detection_reconcile"></a> [administrative\_stack\_drift\_detection\_reconcile](#input\_administrative\_stack\_drift\_detection\_reconcile) | Flag to enable/disable administrative stack drift automatic reconciliation. If drift is detected and `reconcile` is turned on, Spacelift will create a tracked run to correct the drift | `bool` | `true` | no |
 | <a name="input_administrative_stack_drift_detection_schedule"></a> [administrative\_stack\_drift\_detection\_schedule](#input\_administrative\_stack\_drift\_detection\_schedule) | List of cron expressions to schedule drift detection for the administrative stack | `list(string)` | <pre>[<br>  "0 4 * * *"<br>]</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ module "stacks" {
   terraform_version     = lookup(var.terraform_version_map, try(each.value.settings.spacelift.terraform_version, ""), var.terraform_version)
   component_root        = coalesce(try(each.value.settings.spacelift.component_root, null), format("%s/%s", var.components_path, coalesce(each.value.base_component, each.value.component)))
   local_preview_enabled = try(each.value.settings.spacelift.local_preview_enabled, null) != null ? each.value.settings.spacelift.local_preview_enabled : var.local_preview_enabled
+  administrative        = try(each.value.settings.spacelift.administrative, null) != null ? each.value.settings.spacelift.administrative : var.administrative
 
   manage_state   = var.manage_state
   worker_pool_id = var.worker_pool_id

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -6,7 +6,7 @@ resource "spacelift_stack" "default" {
   count = var.enabled ? 1 : 0
 
   name                 = var.stack_name
-  administrative       = false
+  administrative       = var.administrative
   autodeploy           = var.autodeploy
   repository           = var.repository
   branch               = var.branch
@@ -14,11 +14,10 @@ resource "spacelift_stack" "default" {
   manage_state         = var.manage_state
   labels               = var.labels
   enable_local_preview = var.local_preview_enabled
-
-  worker_pool_id      = var.worker_pool_id
-  runner_image        = var.runner_image
-  terraform_version   = var.terraform_version
-  terraform_workspace = var.terraform_workspace
+  worker_pool_id       = var.worker_pool_id
+  runner_image         = var.runner_image
+  terraform_version    = var.terraform_version
+  terraform_workspace  = var.terraform_workspace
 }
 
 resource "spacelift_run" "default" {

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -178,3 +178,9 @@ variable "stack_destructor_enabled" {
   description = "Flag to enable/disable the stack destructor to destroy the resources of the stack before deleting the stack itself"
   default     = false
 }
+
+variable "administrative" {
+  type        = bool
+  description = "Whether this stack can manage others"
+  default     = false
+}

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -181,6 +181,6 @@ variable "stack_destructor_enabled" {
 
 variable "administrative" {
   type        = bool
-  description = "Whether this stack can manage others"
+  description = "Whether this stack can manage other stacks"
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -241,3 +241,9 @@ variable "stack_destructor_enabled" {
   description = "Flag to enable/disable the stack destructor to destroy the resources of a stack before deleting the stack itself"
   default     = false
 }
+
+variable "administrative" {
+  type        = bool
+  description = "Whether this stack can manage others"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -244,6 +244,6 @@ variable "stack_destructor_enabled" {
 
 variable "administrative" {
   type        = bool
-  description = "Whether this stack can manage others"
+  description = "Whether this stack can manage other stacks"
   default     = false
 }


### PR DESCRIPTION
## what
* Add administrative

## why
* Be able to create administrative stacks by updating a boolean
* This would be necessary if we needed to create an service specific admin stack for its preview environment
* This also opens up managing administrative stacks by using the `modules/stack` module directly

## references
N/A

