### PR TITLE
Expose before/after

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,17 @@ module "stacks" {
   ) : var.aws_role_generate_credentials_in_worker
 
   stack_destructor_enabled = try(each.value.settings.spacelift.stack_destructor_enabled, null) != null ? each.value.settings.spacelift.stack_destructor_enabled : var.stack_destructor_enabled
+
+  after_apply    = try(each.value.settings.after_apply, null) != null ? each.value.settings.after_apply : var.after_apply
+  after_destroy  = try(each.value.settings.after_destroy, null) != null ? each.value.settings.after_destroy : var.after_destroy
+  after_init     = try(each.value.settings.after_init, null) != null ? each.value.settings.after_init : var.after_init
+  after_perform  = try(each.value.settings.after_perform, null) != null ? each.value.settings.after_perform : var.after_perform
+  after_plan     = try(each.value.settings.after_plan, null) != null ? each.value.settings.after_plan : var.after_plan
+  before_apply   = try(each.value.settings.before_apply, null) != null ? each.value.settings.before_apply : var.before_apply
+  before_destroy = try(each.value.settings.before_destroy, null) != null ? each.value.settings.before_destroy : var.before_destroy
+  before_init    = try(each.value.settings.before_init, null) != null ? each.value.settings.before_init : var.before_init
+  before_perform = try(each.value.settings.before_perform, null) != null ? each.value.settings.before_perform : var.before_perform
+  before_plan    = try(each.value.settings.before_plan, null) != null ? each.value.settings.before_plan : var.before_plan
 }
 
 # `administrative` policies are always attached to the `administrative` stack

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -19,6 +19,18 @@ resource "spacelift_stack" "default" {
   runner_image        = var.runner_image
   terraform_version   = var.terraform_version
   terraform_workspace = var.terraform_workspace
+
+
+  after_apply    = var.after_apply
+  after_destroy  = var.after_destroy
+  after_init     = var.after_init
+  after_perform  = var.after_perform
+  after_plan     = var.after_plan
+  before_apply   = var.before_apply
+  before_destroy = var.before_destroy
+  before_init    = var.before_init
+  before_perform = var.before_perform
+  before_plan    = var.before_plan
 }
 
 resource "spacelift_run" "default" {

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -178,3 +178,63 @@ variable "stack_destructor_enabled" {
   description = "Flag to enable/disable the stack destructor to destroy the resources of the stack before deleting the stack itself"
   default     = false
 }
+
+variable "before_apply" {
+  type        = list(string)
+  description = "List of before-apply scripts"
+  default     = []
+}
+
+variable "before_destroy" {
+  type        = list(string)
+  description = "List of before-destroy scripts"
+  default     = []
+}
+
+variable "before_init" {
+  type        = list(string)
+  description = "List of before-init scripts"
+  default     = []
+}
+
+variable "before_perform" {
+  type        = list(string)
+  description = "List of before-perform scripts"
+  default     = []
+}
+
+variable "before_plan" {
+  type        = list(string)
+  description = "List of before-plan scripts"
+  default     = []
+}
+
+variable "after_apply" {
+  type        = list(string)
+  description = "List of after-apply scripts"
+  default     = []
+}
+
+variable "after_destroy" {
+  type        = list(string)
+  description = "List of after-destroy scripts"
+  default     = []
+}
+
+variable "after_init" {
+  type        = list(string)
+  description = "List of after-init scripts"
+  default     = []
+}
+
+variable "after_perform" {
+  type        = list(string)
+  description = "List of after-perform scripts"
+  default     = []
+}
+
+variable "after_plan" {
+  type        = list(string)
+  description = "List of after-plan scripts"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -241,3 +241,63 @@ variable "stack_destructor_enabled" {
   description = "Flag to enable/disable the stack destructor to destroy the resources of a stack before deleting the stack itself"
   default     = false
 }
+
+variable "before_apply" {
+  type        = list(string)
+  description = "List of before-apply scripts"
+  default     = []
+}
+
+variable "before_destroy" {
+  type        = list(string)
+  description = "List of before-destroy scripts"
+  default     = []
+}
+
+variable "before_init" {
+  type        = list(string)
+  description = "List of before-init scripts"
+  default     = []
+}
+
+variable "before_perform" {
+  type        = list(string)
+  description = "List of before-perform scripts"
+  default     = []
+}
+
+variable "before_plan" {
+  type        = list(string)
+  description = "List of before-plan scripts"
+  default     = []
+}
+
+variable "after_apply" {
+  type        = list(string)
+  description = "List of after-apply scripts"
+  default     = []
+}
+
+variable "after_destroy" {
+  type        = list(string)
+  description = "List of after-destroy scripts"
+  default     = []
+}
+
+variable "after_init" {
+  type        = list(string)
+  description = "List of after-init scripts"
+  default     = []
+}
+
+variable "after_perform" {
+  type        = list(string)
+  description = "List of after-perform scripts"
+  default     = []
+}
+
+variable "after_plan" {
+  type        = list(string)
+  description = "List of after-plan scripts"
+  default     = []
+}


### PR DESCRIPTION
## what
* Expose before/after

## why
* When creating infrastructure stacks in non infrastructure repositories, the `.spacelift/` directory has to be copied over
* This would enable us to optionally allow running some scripts globally without a `.spacelift` dir
* This is a WIP.

## references
N/A

