### PR TITLE
feat: adds support for attaching contexts + bumps provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.0.5 |
+| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.0.5 |
+| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.1.2 |
 
 ## Modules
 
@@ -252,6 +252,7 @@ Available targets:
 | <a name="input_component_deps_processing_enabled"></a> [component\_deps\_processing\_enabled](#input\_component\_deps\_processing\_enabled) | Boolean flag to enable/disable processing stack config dependencies for the components in the provided stack | `bool` | `true` | no |
 | <a name="input_components_path"></a> [components\_path](#input\_components\_path) | The relative pathname for where all components reside | `string` | `"components"` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_context_attachments"></a> [context\_attachments](#input\_context\_attachments) | A list of context IDs to attach to all stacks administered by this module | `list(string)` | `[]` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_drift_detection_enabled"></a> [drift\_detection\_enabled](#input\_drift\_detection\_enabled) | Flag to enable/disable drift detection on the infrastructure stacks | `bool` | `false` | no |
 | <a name="input_drift_detection_reconcile"></a> [drift\_detection\_reconcile](#input\_drift\_detection\_reconcile) | Flag to enable/disable infrastructure stacks drift automatic reconciliation. If drift is detected and `reconcile` is turned on, Spacelift will create a tracked run to correct the drift | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.0.5 |
+| <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | >= 0.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.0.5 |
+| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | >= 0.1.2 |
 
 ## Modules
 
@@ -62,6 +62,7 @@
 | <a name="input_component_deps_processing_enabled"></a> [component\_deps\_processing\_enabled](#input\_component\_deps\_processing\_enabled) | Boolean flag to enable/disable processing stack config dependencies for the components in the provided stack | `bool` | `true` | no |
 | <a name="input_components_path"></a> [components\_path](#input\_components\_path) | The relative pathname for where all components reside | `string` | `"components"` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_context_attachments"></a> [context\_attachments](#input\_context\_attachments) | A list of context IDs to attach to all stacks administered by this module | `list(string)` | `[]` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_drift_detection_enabled"></a> [drift\_detection\_enabled](#input\_drift\_detection\_enabled) | Flag to enable/disable drift detection on the infrastructure stacks | `bool` | `false` | no |
 | <a name="input_drift_detection_reconcile"></a> [drift\_detection\_reconcile](#input\_drift\_detection\_reconcile) | Flag to enable/disable infrastructure stacks drift automatic reconciliation. If drift is detected and `reconcile` is turned on, Spacelift will create a tracked run to correct the drift | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ module "stacks" {
   terraform_workspace       = each.value.workspace
   labels                    = each.value.labels
 
+  context_attachments  = coalesce(try(each.value.settings.spacelift.context_attachments, null), var.context_attachments)
   autodeploy            = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
   branch                = coalesce(try(each.value.settings.spacelift.branch, null), var.branch)
   repository            = coalesce(try(each.value.settings.spacelift.repository, null), var.repository)

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ module "stacks" {
   terraform_workspace       = each.value.workspace
   labels                    = each.value.labels
 
-  context_attachments  = coalesce(try(each.value.settings.spacelift.context_attachments, null), var.context_attachments)
+  context_attachments   = coalesce(try(each.value.settings.spacelift.context_attachments, null), var.context_attachments)
   autodeploy            = coalesce(try(each.value.settings.spacelift.autodeploy, null), var.autodeploy)
   branch                = coalesce(try(each.value.settings.spacelift.branch, null), var.branch)
   repository            = coalesce(try(each.value.settings.spacelift.repository, null), var.repository)

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -1,5 +1,12 @@
 locals {
   component_env = { for k, v in var.component_env : k => v if var.enabled == true }
+
+  # Create a map of the given context_attachments so we have the index (for priority)
+  # and pretty names for the resource paths.
+  context_attachments_map = {
+    for idx, context_id in var.context_attachments:
+    context_id => idx
+  }
 }
 
 resource "spacelift_stack" "default" {
@@ -129,4 +136,12 @@ resource "spacelift_stack_destructor" "default" {
     spacelift_policy_attachment.default,
     spacelift_aws_role.default
   ]
+}
+
+resource "spacelift_context_attachment" "attachment" {
+  for_each = local.context_attachments_map
+
+  context_id = each.key
+  stack_id   = spacelift_stack.default[0].id
+  priority   = each.value
 }

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -4,7 +4,7 @@ locals {
   # Create a map of the given context_attachments so we have the index (for priority)
   # and pretty names for the resource paths.
   context_attachments_map = {
-    for idx, context_id in var.context_attachments:
+    for idx, context_id in var.context_attachments :
     context_id => idx
   }
 }

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -244,3 +244,9 @@ variable "administrative" {
   description = "Whether this stack can manage other stacks"
   default     = false
 }
+
+variable "context_attachments" {
+  type        = list(string)
+  description = "A list of context IDs to attach to this stack"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -313,3 +313,9 @@ variable "administrative" {
   description = "Whether this stack can manage other stacks"
   default     = false
 }
+
+variable "context_attachments" {
+  type        = list(string)
+  description = "A list of context IDs to attach to all stacks administered by this module"
+  default     = []
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     spacelift = {
       source  = "spacelift-io/spacelift"
-      version = ">= 0.0.5"
+      version = ">= 0.1.2"
     }
   }
 }


### PR DESCRIPTION
## what
* Adds support for Spacelift Context attachments: https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/context_attachment
* Bumps Spacelift provider required version to `>= 0.1.2` (latest)

## why
* Enables sharing many variables easily across many Spacelift Stacks.
* Provider version bump is due to the `before_*` (and friends) arguments as they error out when utilizing an older provider version (`0.0.4` I'd guess). See 
<img width="1680" alt="CleanShot 2021-09-10 at 12 17 31@2x" src="https://user-images.githubusercontent.com/1392040/132885328-ebfd07ae-420d-40d4-a227-3e268e0f4357.png">

## references
* N/A

