### PR TITLE
Update `proposed-run` Rego push policy

### DIFF
--- a/catalog/policies/git_push.default.rego
+++ b/catalog/policies/git_push.default.rego
@@ -76,7 +76,7 @@ stack_config_affected {
 labels := input.stack.labels
 
 # Get stack imports from the provided `labels`
-# NOTE: procesing of stack imports is disabled in the module (var.imports_processing_enabled == false),
+# NOTE: procesing of stack imports is disabled in the module (var.imports_processing_enabled = false),
 # and the below rules will not be evaluated by default
 # https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions
 imports := [imp | startswith(labels[i], "import:"); imp := split(labels[i], ":")[1]]
@@ -87,7 +87,7 @@ stack_config_affected {
 }
 
 # Get all stack dependencies for the component from the provided `labels` (all stacks where the component is defined)
-# NOTE: procesing of all stack dependencies is disabled in the module (var.stack_deps_processing_enabled == false),
+# NOTE: procesing of all stack dependencies is disabled in the module (var.stack_deps_processing_enabled = false),
 # and the below rules will not be evaluated by default
 stack_deps := [stack_dep | startswith(labels[i], "stack:"); stack_dep := split(labels[i], ":")[1]]
 

--- a/catalog/policies/git_push.head-diff.rego
+++ b/catalog/policies/git_push.head-diff.rego
@@ -76,7 +76,7 @@ stack_config_affected {
 labels := input.stack.labels
 
 # Get stack imports from the provided `labels`
-# NOTE: procesing of stack imports is disabled in the module (var.imports_processing_enabled == false),
+# NOTE: procesing of stack imports is disabled in the module (var.imports_processing_enabled = false),
 # and the below rules will not be evaluated by default
 # https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions
 imports := [imp | startswith(labels[i], "import:"); imp := split(labels[i], ":")[1]]
@@ -87,7 +87,7 @@ stack_config_affected {
 }
 
 # Get all stack dependencies for the component from the provided `labels` (all stacks where the component is defined)
-# NOTE: procesing of all stack dependencies is disabled in the module (var.stack_deps_processing_enabled == false),
+# NOTE: procesing of all stack dependencies is disabled in the module (var.stack_deps_processing_enabled = false),
 # and the below rules will not be evaluated by default
 stack_deps := [stack_dep | startswith(labels[i], "stack:"); stack_dep := split(labels[i], ":")[1]]
 

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -19,9 +19,9 @@ project_root := input.stack.project_root
 proposed_run_pull_request_actions := {"opened", "reopened", "synchronize"}
 
 # Ignore if any of the `ignore` rules evaluates to `true`
-# If pre-commit hooks make changes, they are not semantic changes and can and should be ignored
+# 1) Ignore if the PR has a label `spacelift-no-trigger`
 ignore  {
-    input.push.message == "pre-commit fixes"
+    input.pull_request.labels[_] = "spacelift-no-trigger"
 }
 
 # Propose a run if component's files are affected and the pull request action is in the `proposed_run_pull_request_actions` array
@@ -60,7 +60,7 @@ stack_config_affected {
 labels := input.stack.labels
 
 # Get stack imports from the provided `labels`
-# NOTE: procesing of stack imports is disabled in the module (var.imports_processing_enabled == false),
+# NOTE: procesing of stack imports is disabled in the module (var.imports_processing_enabled = false),
 # and the below rules will not be evaluated by default
 # https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions
 imports := [imp | startswith(labels[i], "import:"); imp := split(labels[i], ":")[1]]
@@ -71,7 +71,7 @@ stack_config_affected {
 }
 
 # Get all stack dependencies for the component from the provided `labels` (all stacks where the component is defined)
-# NOTE: procesing of all stack dependencies is disabled in the module (var.stack_deps_processing_enabled == false),
+# NOTE: procesing of all stack dependencies is disabled in the module (var.stack_deps_processing_enabled = false),
 # and the below rules will not be evaluated by default
 stack_deps := [stack_dep | startswith(labels[i], "stack:"); stack_dep := split(labels[i], ":")[1]]
 

--- a/catalog/policies/git_push.tracked-run.rego
+++ b/catalog/policies/git_push.tracked-run.rego
@@ -50,7 +50,7 @@ stack_config_affected {
 labels := input.stack.labels
 
 # Get stack imports from the provided `labels`
-# NOTE: procesing of stack imports is disabled in the module (var.imports_processing_enabled == false),
+# NOTE: procesing of stack imports is disabled in the module (var.imports_processing_enabled = false),
 # and the below rules will not be evaluated by default
 # https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions
 imports := [imp | startswith(labels[i], "import:"); imp := split(labels[i], ":")[1]]
@@ -61,7 +61,7 @@ stack_config_affected {
 }
 
 # Get all stack dependencies for the component from the provided `labels` (all stacks where the component is defined)
-# NOTE: procesing of all stack dependencies is disabled in the module (var.stack_deps_processing_enabled == false),
+# NOTE: procesing of all stack dependencies is disabled in the module (var.stack_deps_processing_enabled = false),
 # and the below rules will not be evaluated by default
 stack_deps := [stack_dep | startswith(labels[i], "stack:"); stack_dep := split(labels[i], ":")[1]]
 


### PR DESCRIPTION
## what
* Update `proposed-run` Rego push policy

## why
* Don't ignore a commit with the message `pre-commit fixes`  because we use `rennovatebot` which pushes commits on which we want to trigger Spacelift stacks
* Ignore if the PR has the label `spacelift-no-trigger` - useful if we need to test and push many commits to the PR but don't want to trigger Spacelift stacks (especially if the commits affects many global files which in turn triggers many Spacelift stacks)

