### PR TITLE
Add canceling runs if new commits are pushed

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ locals {
   stacks             = [for f in local.stack_config_files : trimsuffix(basename(f), ".yaml")]
 }
 
-module "example" {
+module "spacelift" {
   source  = "cloudposse/cloud-infrastructure-automation/spacelift"
-  version = "x.x.x"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
 
   stacks                     = local.stacks
   stack_config_path          = var.stack_config_path

--- a/README.md
+++ b/README.md
@@ -510,8 +510,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Dan Meyers][danjbh_avatar]][danjbh_homepage]<br/>[Dan Meyers][danjbh_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] |
-|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Dan Meyers][danjbh_avatar]][danjbh_homepage]<br/>[Dan Meyers][danjbh_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
+|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -520,6 +520,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [danjbh_avatar]: https://img.cloudposse.com/150x150/https://github.com/danjbh.png
   [aknysh_homepage]: https://github.com/aknysh
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -221,3 +221,6 @@ contributors:
     github: "danjbh"
   - name: "Andriy Knysh"
     github: "aknysh"
+  - name: "RB"
+    github: "nitrocode"
+

--- a/README.yaml
+++ b/README.yaml
@@ -108,9 +108,10 @@ usage: |-
     stacks             = [for f in local.stack_config_files : trimsuffix(basename(f), ".yaml")]
   }
 
-  module "example" {
+  module "spacelift" {
     source  = "cloudposse/cloud-infrastructure-automation/spacelift"
-    version = "x.x.x"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
 
     stacks                     = local.stacks
     stack_config_path          = var.stack_config_path

--- a/catalog/policies/git_push.default.rego
+++ b/catalog/policies/git_push.default.rego
@@ -109,5 +109,3 @@ stack_config_affected {
 stack_config_affected {
     startswith(affected_files[_], deps[_])
 }
-
-cancel[run.id] { run := input.in_progress[_] }

--- a/catalog/policies/git_push.default.rego
+++ b/catalog/policies/git_push.default.rego
@@ -109,3 +109,5 @@ stack_config_affected {
 stack_config_affected {
     startswith(affected_files[_], deps[_])
 }
+
+cancel[run.id] { run := input.in_progress[_] }

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -94,7 +94,8 @@ stack_config_affected {
     startswith(affected_files[_], deps[_])
 }
 
-# Cancel previous runs if a new commit is pushed
+# Cancel previous queued proposed runs if a new commit is pushed
+# Tracked runs will not be cancelled
 # https://docs.spacelift.io/concepts/policy/git-push-policy#canceling-in-progress-runs
 cancel[run.id] {
   run := input.in_progress[_]

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -95,4 +95,9 @@ stack_config_affected {
 }
 
 # Cancel previous runs if a new commit is pushed
-cancel[run.id] { run := input.in_progress[_] }
+# https://docs.spacelift.io/concepts/policy/git-push-policy#canceling-in-progress-runs
+cancel[run.id] {
+  run := input.in_progress[_]
+  run.type == "PROPOSED"
+  run.state == "QUEUED"
+}

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -93,3 +93,6 @@ stack_config_affected {
 stack_config_affected {
     startswith(affected_files[_], deps[_])
 }
+
+# Cancel previous runs if a new commit is pushed
+cancel[run.id] { run := input.in_progress[_] }


### PR DESCRIPTION
## what
* Add canceling runs if new commits are pushed

## why
* No use in planning spacelift stacks for older commits. We might as well cancel stacks that are queued and only plan the newer stacks.
* Purposely not added to `git_push.default` because that is a deprecated rego policy

## references
* https://docs.spacelift.io/concepts/policy/git-push-policy#canceling-in-progress-runs

