### PR TITLE
Fix Spacelift stacks context filters

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -47,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-2021 Cloud Posse, LLC
+   Copyright 2020-2022 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -26,10 +26,11 @@ locals {
   spacelift_stacks = {
     for k, v in module.spacelift_config.spacelift_stacks :
     k => v
-    if(lookup(var.context_filters, "namespaces", null) == null || contains(lookup(var.context_filters, "namespaces", [v.vars.namespace]), v.vars.namespace)) &&
-    (lookup(var.context_filters, "tenants", null) == null || contains(lookup(var.context_filters, "tenants", [v.vars.tenant]), v.vars.tenant)) &&
-    (lookup(var.context_filters, "environments", null) == null || contains(lookup(var.context_filters, "environments", [v.vars.environment]), v.vars.environment)) &&
-    (lookup(var.context_filters, "stages", null) == null || contains(lookup(var.context_filters, "stages", [v.vars.stage]), v.vars.stage))
+    if
+    (lookup(var.context_filters, "namespaces", null) == null || contains(lookup(var.context_filters, "namespaces", [lookup(v.vars, "namespace", "")]), lookup(v.vars, "namespace", ""))) &&
+    (lookup(var.context_filters, "tenants", null) == null || contains(lookup(var.context_filters, "tenants", [lookup(v.vars, "tenant", "")]), lookup(v.vars, "tenant", ""))) &&
+    (lookup(var.context_filters, "environments", null) == null || contains(lookup(var.context_filters, "environments", [lookup(v.vars, "environment", "")]), lookup(v.vars, "environment", ""))) &&
+    (lookup(var.context_filters, "stages", null) == null || contains(lookup(var.context_filters, "stages", [lookup(v.vars, "stage", "")]), lookup(v.vars, "stage", "")))
   }
 
   # Find Rego policies defined in YAML config in all stacks


### PR DESCRIPTION
## what
* Fix Spacelift stacks context filters

## why
* In terraform, both sides of the OR operator are always evaluated
* When provisioning Spacelift stacks for clients that don't use `tenant`, the module threw the error

```
Error: Unsupported attribute
  on .terraform/modules/spacelift/main.tf line 30, in locals:
  30:     (lookup(var.context_filters, "tenants", null) == null || contains(lookup(var.context_filters, "tenants", 
[v.vars.tenant]), v.vars.tenant)) &&
    |----------------
    | v.vars is object with 4 attributes

This object does not have an attribute named "tenant".
```

* Use `lookup` with a default to prevent these errors

