### PR TITLE
Fix: Properly Toggle Stack Destructor Functionality via `var.stack_destructor_enabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,8 +511,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Dan Meyers][danjbh_avatar]][danjbh_homepage]<br/>[Dan Meyers][danjbh_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
-|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Dan Meyers][danjbh_avatar]][danjbh_homepage]<br/>[Dan Meyers][danjbh_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
+|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -523,6 +523,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [nitrocode_homepage]: https://github.com/nitrocode
   [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
+  [korenyoni_homepage]: https://github.com/korenyoni
+  [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -224,4 +224,6 @@ contributors:
     github: "aknysh"
   - name: "RB"
     github: "nitrocode"
+  - name: "Yonatan Koren"
+    github: "korenyoni"
 

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -125,10 +125,17 @@ resource "spacelift_aws_role" "default" {
   generate_credentials_in_worker = var.aws_role_generate_credentials_in_worker
 }
 
+# spacelift_stack_destructor is a special resource which, when deleted, will delete all resources in the stack.
+# var.stack_destructor_enabled should not toggle the creation or destruction of this resource, because toggling it from
+# 'true' to 'false' with the intention of disabling the stack destructor functionality will result in all of the resources
+# in the stack being deleted. Instead, this resource is always created, with var.stack_destructor_enabled toggling its
+# 'deactivated' attribute, which allows for the stack destructor functionality to be disabled.
+# See: https://github.com/spacelift-io/terraform-provider-spacelift/blob/master/spacelift/resource_stack_destructor.go
 resource "spacelift_stack_destructor" "default" {
-  count = var.enabled && var.stack_destructor_enabled ? 1 : 0
+  count = var.enabled ? 1 : 0
 
-  stack_id = spacelift_stack.default[0].id
+  stack_id    = spacelift_stack.default[0].id
+  deactivated = ! var.stack_destructor_enabled
 
   depends_on = [
     spacelift_mounted_file.stack_config,


### PR DESCRIPTION
## what

Always create `spacelift_stack_destructor` resource; toggle stack destructor functionality via `deactivated` attribute in `spacelift_stack_destructor`, rather than the `count` meta-attribute (see below on reason why).

## why

The `spacelift_stack_destructor` resource is a special resource which, when deleted, will delete all resources in the stack:

https://github.com/spacelift-io/terraform-provider-spacelift/blob/6b9411707f6243ffa956e06bdaa1659820250c35/spacelift/resource_stack_destructor.go#L78-L104

Because of this, `var.stack_destructor_enabled` should not toggle the creation or destruction of this resource, since toggling it from `true` to `false` with the intention of disabling the stack destructor functionality will result in all of the resources in the stack being deleted. Instead, this resource should always created (when `var.enabled` is true), with `var.stack_destructor_enabled` toggling its `deactivated` attribute, which allows for the stack destructor functionality to be disabled.

## references
* https://github.com/spacelift-io/terraform-provider-spacelift/pull/260
* https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack_destructor

