### PR TITLE
Ignore spacelift runs on draft PRs

### DIFF
--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -24,6 +24,12 @@ ignore  {
     input.pull_request.labels[_] = "spacelift-no-trigger"
 }
 
+# Ignore draft PRs unless they explicitly have a `spacelift-trigger` label
+ignore {
+   input.pull_request.draft = true
+   input.pull_request.labels[_] != "spacelift-trigger"
+}
+
 # Propose a run if component's files are affected and the pull request action is in the `proposed_run_pull_request_actions` array
 # https://docs.spacelift.io/concepts/run/proposed
 propose {

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -26,7 +26,7 @@ ignore  {
 
 # Ignore draft PRs unless they explicitly have a `spacelift-trigger` label
 ignore {
-   input.pull_request.draft = true
+   input.pull_request.draft
    input.pull_request.labels[_] != "spacelift-trigger"
 }
 


### PR DESCRIPTION
## what
* Ignore spacelift runs on draft PRs
* Waiting on team feedback

## why
* Reduce noise

## references
* N/A

## test

Draft

<details><summary>This has `draft: true` and `labels: ["spacelift-trigger"]` so it should run spacelift</summary>

```json
{
  "in_progress": [],
  "pull_request": {
    "action": "merged",
    "action_initiator": "nitrocode",
    "author": "nitrocode",
    "base": {
      "author": "nitrocode",
      "branch": "main",
      "created_at": 1651002899000000000,
      "hash": "fdd4011c23a012b358eacec4bbf4143aa97cdae2",
      "message": "snip"
    },
    "diff": ["components/terraform/ses/README.md", "components/terraform/ses/main.tf", "components/terraform/ses/variables.tf", "stacks/catalog/ses.yaml"],
    "draft": true,
    "head": {
      "author": "nitrocode",
      "branch": "ses-spacelift",
      "created_at": 1651071679000000000,
      "hash": "93e1fcd38dbff15b07293783a15428bbb2e623b6",
      "message": "Update ses.yaml"
    },
    "id": 524,
    "labels": ["spacelift-trigger"],
    "title": "Document ses disabled in spacelift"
  },
  "push": {
    "affected_files": ["components/terraform/ses/README.md", "components/terraform/ses/main.tf", "components/terraform/ses/variables.tf", "stacks/catalog/ses.yaml"],
    "author": "nitrocode",
    "branch": "main",
    "created_at": 1651258425000000000,
    "hash": "1be4b2a32fb0fc51feabce00532b0b7663825660",
    "message": "snip",
    "tag": ""
  },
  "stack": {
    "administrative": false,
    "autodeploy": false,
    "branch": "main",
    "id": "ue1-network-vpc-flow-logs-log-group",
    "labels": ["deps:stacks/catalog/cloudwatch-logs.yaml", "deps:stacks/catalog/vpc.yaml", "deps:stacks/globals.yaml", "deps:stacks/ue1-globals.yaml", "deps:stacks/ue1-network.yaml", "folder:component/vpc-flow-logs-log-group", "folder:ue1/network"],
    "locked_by": null,
    "name": "ue1-network-vpc-flow-logs-log-group",
    "namespace": "",
    "project_root": "components/terraform/cloudwatch-logs",
    "repository": "infrastructure",
    "state": "FINISHED",
    "terraform_version": "1.0.8",
    "tracked_commit": {
      "author": "nitrocode",
      "branch": "main",
      "created_at": 1650997771000000000,
      "hash": "snip",
      "message": "snip"
    },
    "worker_pool": {
      "id": "snip",
      "labels": [],
      "name": "Primary Worker Pool ue1",
      "public": false
    }
  },
  "stacks": []
}
```

Simulation shows correct ignore

```json
{
  "cancel": [],
  "ignore": false,
}
```

</details>

<details><summary>This has `draft: true` and `labels: [""]` so it should ignore spacelift</summary>

Simulation shows correct ignore

```json
{
  "cancel": [],
  "ignore": true,
}
```

</details>

Ready to review (this is preserved)

<details><summary>This has `draft: false` and `labels: [""]` so it should run spacelift</summary>

Simulation shows correct ignore

```json
{
  "cancel": [],
  "ignore": false,
}
```

</details>

<details><summary>This has `draft: false` and `labels: ["spacelift-no-trigger"]` so it should ignore spacelift</summary>

Simulation shows correct ignore

```json
{
  "cancel": [],
  "ignore": true,
}
```

</details>