### PR TITLE
Fix unignored draft prs if no pr labels

### DIFF
--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -25,14 +25,14 @@ ignore  {
 }
 
 # Ignore draft PRs unless they explicitly have a `spacelift-trigger` label
+# This ignore statement assumes count(input.pull_request.labels) > 0
 ignore {
    input.pull_request.draft
-   # we can only check if labels contains something if there is more than one label
-   count(input.pull_request.labels) > 0
    input.pull_request.labels[_] != "spacelift-trigger"
 }
 
-# Ignore draft PRs if they have 0 labels
+# Ignore draft PRs if there are 0 labels.
+# If this block isn't there, the above ignore policy will result in false unless there is at least one label present.
 ignore {
    input.pull_request.draft
    count(input.pull_request.labels) == 0

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -25,17 +25,14 @@ ignore  {
 }
 
 # Ignore draft PRs unless they explicitly have a `spacelift-trigger` label
-# This ignore statement assumes count(input.pull_request.labels) > 0
-ignore {
-   input.pull_request.draft
-   input.pull_request.labels[_] != "spacelift-trigger"
+# This function and the following "not" expression allows working with zero and non-zero "labels" counts
+has_spacelift_trigger_label {
+  input.pull_request.labels[_] == "spacelift-trigger"
 }
 
-# Ignore draft PRs if there are 0 labels.
-# If this block isn't there, the above ignore policy will result in false unless there is at least one label present.
 ignore {
    input.pull_request.draft
-   count(input.pull_request.labels) == 0
+   not has_spacelift_trigger_label
 }
 
 # Propose a run if component's files are affected and the pull request action is in the `proposed_run_pull_request_actions` array

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -27,7 +27,15 @@ ignore  {
 # Ignore draft PRs unless they explicitly have a `spacelift-trigger` label
 ignore {
    input.pull_request.draft
+   # we can only check if labels contains something if there is more than one label
+   count(input.pull_request.labels) > 0
    input.pull_request.labels[_] != "spacelift-trigger"
+}
+
+# Ignore draft PRs if they have 0 labels
+ignore {
+   input.pull_request.draft
+   count(input.pull_request.labels) == 0
 }
 
 # Propose a run if component's files are affected and the pull request action is in the `proposed_run_pull_request_actions` array


### PR DESCRIPTION
## what
* Fix unignored draft prs

## why
* There is an issue if a draft PR has zero PR labels, the push proposed policy will still trigger a plan
* This will explicitly set an ignore on both conditions: 1) if draft and no spacelift-trigger label and 2) if draft and no labels

## references
N/A

