### PR TITLE
Allow draft actions in proposed

### DIFF
--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -14,7 +14,7 @@ tracked_extensions := {".tf", ".tf.json", ".tfvars", ".yaml", ".yml", ".tpl", ".
 # Project root
 project_root := input.stack.project_root
 
-# Currently supported actions are: opened, reopened, merged, edited, synchronize, labeled, unlabeled
+# Currently supported actions are: opened, reopened, merged, edited, synchronize, labeled, unlabeled, draft
 # List of PR actions to trigger a proposed run
 proposed_run_pull_request_actions := {"opened", "reopened", "synchronize", "draft"}
 

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -16,7 +16,7 @@ project_root := input.stack.project_root
 
 # Currently supported actions are: opened, reopened, merged, edited, synchronize, labeled, unlabeled
 # List of PR actions to trigger a proposed run
-proposed_run_pull_request_actions := {"opened", "reopened", "synchronize"}
+proposed_run_pull_request_actions := {"opened", "reopened", "synchronize", "draft"}
 
 # Ignore if any of the `ignore` rules evaluates to `true`
 # 1) Ignore if the PR has a label `spacelift-no-trigger`


### PR DESCRIPTION
## what
* [x] Allow draft actions in proposed by using the normalized spacelift pull request action `draft`
* [x] Tested within a PR

> We try to translate that into a common language for all VCS providers.
> So in our lingo that’s “draft”.
> Regardless of whether you’re using GitHub, GitLab or Azure DevOps (Bitbucket doesn’t have that concept).

And this is why we aren't using something like a github specific event i.e. `converted_to_draft` or `ready_for_review`

## why
* To allow draft or non draft events to toggle proposed stacks

## references
* Thank you @marcinwyszynski from Spacelift 
* Pull request actions (draft is undocumented) https://docs.spacelift.io/concepts/policy/git-push-policy#data-input
* https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-34
* https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

