### PR TITLE
Add git push proposed run test

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.rego]
+indent_size = 2
+indent_style = space
+
 [*.{tf,tfvars}]
 indent_size = 2
 indent_style = space

--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -21,7 +21,7 @@ proposed_run_pull_request_actions := {"opened", "reopened", "synchronize", "draf
 # Ignore if any of the `ignore` rules evaluates to `true`
 # 1) Ignore if the PR has a label `spacelift-no-trigger`
 ignore  {
-    input.pull_request.labels[_] = "spacelift-no-trigger"
+  input.pull_request.labels[_] = "spacelift-no-trigger"
 }
 
 # Ignore draft PRs unless they explicitly have a `spacelift-trigger` label
@@ -31,22 +31,22 @@ has_spacelift_trigger_label {
 }
 
 ignore {
-   input.pull_request.draft
-   not has_spacelift_trigger_label
+  input.pull_request.draft
+  not has_spacelift_trigger_label
 }
 
 # Propose a run if component's files are affected and the pull request action is in the `proposed_run_pull_request_actions` array
 # https://docs.spacelift.io/concepts/run/proposed
 propose {
-    project_affected
-    proposed_run_pull_request_actions[_] = input.pull_request.action
+  project_affected
+  proposed_run_pull_request_actions[_] = input.pull_request.action
 }
 
 # Propose a run if component's stack config files are affected and the pull request action is in the `proposed_run_pull_request_actions` array
 # https://docs.spacelift.io/concepts/run/proposed
 propose {
-    stack_config_affected
-    proposed_run_pull_request_actions[_] = input.pull_request.action
+  stack_config_affected
+  proposed_run_pull_request_actions[_] = input.pull_request.action
 }
 
 # Check if any of the tracked extensions were modified in the project folder
@@ -54,9 +54,9 @@ propose {
 # https://www.openpolicyagent.org/docs/latest/policy-language/#variable-keys
 # https://www.openpolicyagent.org/docs/latest/policy-reference/#iteration
 project_affected {
-    some i, j
-    startswith(affected_files[i], project_root)
-    endswith(affected_files[i], tracked_extensions[j])
+  some i, j
+  startswith(affected_files[i], project_root)
+  endswith(affected_files[i], tracked_extensions[j])
 }
 
 # Split the stack name into a list
@@ -64,7 +64,7 @@ stack_name_parts := split(input.stack.name, "-")
 
 # Check if the environment has been modified
 stack_config_affected {
-    contains(affected_files[_], concat("-", [stack_name_parts[0], stack_name_parts[1]]))
+  contains(affected_files[_], concat("-", [stack_name_parts[0], stack_name_parts[1]]))
 }
 
 # Get labels
@@ -78,7 +78,7 @@ imports := [imp | startswith(labels[i], "import:"); imp := split(labels[i], ":")
 
 # Check if any of the imports have been modified
 stack_config_affected {
-    endswith(affected_files[_], imports[_])
+  endswith(affected_files[_], imports[_])
 }
 
 # Get all stack dependencies for the component from the provided `labels` (all stacks where the component is defined)
@@ -88,7 +88,7 @@ stack_deps := [stack_dep | startswith(labels[i], "stack:"); stack_dep := split(l
 
 # Check if any of the stack dependencies have been modified
 stack_config_affected {
-    endswith(affected_files[_], stack_deps[_])
+  endswith(affected_files[_], stack_deps[_])
 }
 
 # Get stack dependencies for the component from the provided `labels`
@@ -97,12 +97,12 @@ deps := [dep | startswith(labels[i], "deps:"); dep := split(labels[i], ":")[1]]
 
 # Check if any of the component stack dependencies have been modified
 stack_config_affected {
-    endswith(affected_files[_], deps[_])
+  endswith(affected_files[_], deps[_])
 }
 
 # Checking startswith allows `deps:*` to reference top level folders
 stack_config_affected {
-    startswith(affected_files[_], deps[_])
+  startswith(affected_files[_], deps[_])
 }
 
 # Cancel previous queued proposed runs if a new commit is pushed

--- a/catalog/policies/git_push.proposed-run_test.rego
+++ b/catalog/policies/git_push.proposed-run_test.rego
@@ -1,0 +1,134 @@
+package spacelift
+
+test_propose_project_root_affected {
+  propose with input as {
+    "stack": {
+      "project_root": "components/terraform/ecr",
+      "labels": [],
+    },
+    "pull_request": {
+      "action": "opened",
+      "draft": false,
+      "labels": [],
+      "diff": ["components/terraform/ecr/main.tf"],
+    },
+  }
+}
+
+test_propose_stack_config_affected_imports_label {
+  propose with input as {
+    "stack": {
+      "project_root": "components/terraform/ecr",
+      "labels": ["import:stacks/catalog/ecr.yaml"],
+    },
+    "pull_request": {
+      "action": "opened",
+      "draft": false,
+      "labels": [],
+      "diff": ["stacks/catalog/ecr.yaml"],
+    },
+  }
+}
+
+test_propose_stack_config_affected_deps_label {
+  propose with input as {
+    "stack": {
+      "project_root": "components/terraform/ecr",
+      "labels": [
+        "deps:stacks/ue2-globals.yaml",
+        "deps:stacks/ue2-artifacts.yaml",
+        "deps:stacks/catalog/ecr.yaml",
+      ],
+    },
+    "pull_request": {
+      "action": "opened",
+      "draft": false,
+      "labels": [],
+      "diff": ["stacks/catalog/ecr.yaml"],
+    },
+  }
+}
+
+test_propose_stack_config_affected_stack_name_root_stack {
+  propose with input as {
+    "stack": {
+      "name": "ue2-artifacts-ecr",
+      "project_root": "components/terraform/ecr",
+      "labels": [],
+    },
+    "pull_request": {
+      "action": "opened",
+      "draft": false,
+      "labels": [],
+      "diff": ["stacks/ue2-artifacts.yaml"],
+    },
+  }
+}
+
+test_propose_stack_config_affected_stack_stack_label {
+  propose with input as {
+    "stack": {
+      "name": "ue2-artifacts-ecr",
+      "project_root": "components/terraform/ecr",
+      "labels": ["stack:stacks/ue2-artifacts.yaml"],
+    },
+    "pull_request": {
+      "action": "opened",
+      "draft": false,
+      "labels": [],
+      "diff": ["stacks/ue2-artifacts.yaml"],
+    },
+  }
+}
+
+test_ignore_ready_to_review_with_spacelift_no_trigger_label {
+  ignore with input as {"pull_request": {
+    "draft": false,
+    "labels": ["spacelift-no-trigger"],
+  }}
+}
+
+test_not_ignore_ready_to_review_without_any_labels {
+  not ignore with input as {"pull_request": {
+    "draft": false,
+    "labels": [],
+  }}
+}
+
+test_not_ignore_draft_with_spacelift_trigger_label {
+  not ignore with input as {"pull_request": {
+    "draft": true,
+    "labels": ["spacelift-trigger"],
+  }}
+}
+
+test_ignore_draft_without_any_labels {
+  ignore with input as {"pull_request": {
+    "draft": true,
+    "labels": [],
+  }}
+}
+
+test_cancel_runs {
+  cancel.test with input as {
+    "pull_request": {"head": {"branch": "main"}},
+    "in_progress": [{
+      "id": "test",
+      "type": "PROPOSED",
+      "state": "QUEUED",
+      "branch": "main",
+    }],
+  }
+}
+
+test_not_cancel_runs {
+  not cancel.test with input as {
+    "pull_request": {"head": {"branch": "feature/example"}},
+    "in_progress": [{
+      "id": "test",
+      "type": "PROPOSED",
+      "state": "QUEUED",
+      "branch": "main",
+    }],
+  }
+}


### PR DESCRIPTION
## what
* Add git push proposed run test
* Explicitly added a *.rego space policy

## why
* This is a large policy and it should be tested if any new changes are introduced
* Consistency
* 100% coverage of `git_push.proposed-run.rego`

## references
* N/A

```
$ opa test git_push.proposed-run.rego git_push.proposed-run_test.rego -v
git_push.proposed-run_test.rego:
data.spacelift.test_propose_project_root_affected: PASS (790.886µs)
data.spacelift.test_propose_stack_config_affected_imports_label: PASS (404.527µs)
data.spacelift.test_propose_stack_config_affected_deps_label: PASS (586.646µs)
data.spacelift.test_propose_stack_config_affected_stack_name_root_stack: PASS (419.415µs)
data.spacelift.test_propose_stack_config_affected_stack_stack_label: PASS (437.601µs)
data.spacelift.test_ignore_ready_to_review_with_spacelift_no_trigger_label: PASS (120.209µs)
data.spacelift.test_not_ignore_ready_to_review_without_any_labels: PASS (109.905µs)
data.spacelift.test_not_ignore_draft_with_spacelift_trigger_label: PASS (134.81µs)
data.spacelift.test_ignore_draft_without_any_labels: PASS (551.992µs)
data.spacelift.test_cancel_runs: PASS (337.658µs)
data.spacelift.test_not_cancel_runs: PASS (128.507µs)
--------------------------------------------------------------------------------
PASS: 11/11
$ opa test git_push.proposed-run.rego git_push.proposed-run_test.rego -v -c | jq .coverage
100
```


