### PR TITLE
Add deny-downgrading-rds-cluster-engine-version policy

### DIFF
--- a/catalog/policies/deny.downgrading-rds-cluster-engine-version.rego
+++ b/catalog/policies/deny.downgrading-rds-cluster-engine-version.rego
@@ -1,0 +1,23 @@
+package spacelift
+
+sample { true }
+
+deny["Major version is downgrading"] {
+    change_after = input.terraform.resource_changes[_].change.after
+    change_before = input.terraform.resource_changes[_].change.before
+    # 14 > 13 so deny will be true (deny downgrade)
+    # 13 > 13 so deny will be false (allow nothing)
+    # 13 > 14 so deny will be false (allow upgrade)
+    to_number(split(change_before.engine_version, ".")[0]) > to_number(split(change_after.engine_version, ".")[0])
+}
+
+deny["Minor version is downgrading"] {
+    change_after = input.terraform.resource_changes[_].change.after
+    change_before = input.terraform.resource_changes[_].change.before
+    # 13 == 13 so deny will be true
+    # 13.8 > 13.8 so deny will be false (allow nothing)
+    # 13.8 > 13.7 so deny will be true (deny downgrade)
+    # 13.7 > 13.8 so deny will be false (allow upgrade)
+    to_number(split(change_before.engine_version, ".")[0]) == to_number(split(change_after.engine_version, ".")[0])
+    to_number(split(change_before.engine_version, ".")[1]) > to_number(split(change_after.engine_version, ".")[1])
+}


### PR DESCRIPTION
## what
* Add deny-downgrading-rds-cluster-engine-version policy

## why
* Prevent engine_version downgrading in spacelift

## references
* It's either this policy or ignoring `engine_version` from the rds cluster which prevents upgrading using terraform
* https://github.com/cloudposse/terraform-aws-rds-cluster/pull/139

