### PR TITLE
Ignore runs if msg == 'pre-commit fixes'

### DIFF
--- a/catalog/policies/git_push.proposed-run.rego
+++ b/catalog/policies/git_push.proposed-run.rego
@@ -30,6 +30,11 @@ has_spacelift_trigger_label {
   input.pull_request.labels[_] == "spacelift-trigger"
 }
 
+# If pre-commit hooks make changes, they are not semantic changes and can and should be ignored
+ignore  {
+    input.push.message == "pre-commit fixes"
+}
+
 ignore {
    input.pull_request.draft
    not has_spacelift_trigger_label


### PR DESCRIPTION
## what
* Ignore runs if msg == 'pre-commit fixes'

## why
* This was a feature in the original default policy `git_push.default.rego`

https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/blob/c39ca03e800f76f45918746f2b5d6a5ba5f906f5/catalog/policies/git_push.default.rego#L16-L19

## references
N/A

## notes

- I'm told that @osterman spoke with a client that ran into an issue where spacelift should have ran and didn't because of this `ignore` and so that's why it was explicitly removed in the newer version of the policy.