### PR TITLE
Separate cancel policy from git push propose policy

### DIFF
--- a/catalog/policies/git_push.auto-cancel.rego
+++ b/catalog/policies/git_push.auto-cancel.rego
@@ -1,0 +1,16 @@
+# https://docs.spacelift.io/concepts/policy/git-push-policy
+# GIT_PUSH policy that triggers proposed runs when component files or YAML config files are modified in pull requests
+
+package spacelift
+
+# Cancel previous queued proposed runs if a new commit is pushed
+# Tracked runs will not be cancelled
+# https://docs.spacelift.io/concepts/policy/git-push-policy#canceling-in-progress-runs
+cancel[run.id] {
+  run := input.in_progress[_]
+  run.type == "PROPOSED"
+  run.state == "QUEUED"
+  run.branch == input.pull_request.head.branch
+}
+
+sample { true }


### PR DESCRIPTION
## what
* Create git_push.auto-cancel.rego

## why
* I want to use the auto cancel policy but separate from the git push policy
* I left the cancel policy in the git push policy so not to disturb current consumers
* I'd like to also trigger this policy on "label" events which shouldn't be set on the git push propose policy

## references
- Current policies https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/tree/master/catalog/policies

