### PR TITLE
Add additional_mounted_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_mounted_files"></a> [additional\_mounted\_files](#input\_additional\_mounted\_files) | Add additional mounted files where the values of each key are `relative_path`, `content`, and optional `write_only` which defaults to `false`. | `map(any)` | `{}` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_administrative"></a> [administrative](#input\_administrative) | Whether this stack can manage other stacks | `bool` | `false` | no |
 | <a name="input_administrative_stack_drift_detection_enabled"></a> [administrative\_stack\_drift\_detection\_enabled](#input\_administrative\_stack\_drift\_detection\_enabled) | Flag to enable/disable administrative stack drift detection | `bool` | `true` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -218,4 +218,3 @@ contributors:
     github: "nitrocode"
   - name: "Yonatan Koren"
     github: "korenyoni"
-

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -37,6 +37,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_mounted_files"></a> [additional\_mounted\_files](#input\_additional\_mounted\_files) | Add additional mounted files where the values of each key are `relative_path`, `content`, and optional `write_only` which defaults to `false`. | `map(any)` | `{}` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_administrative"></a> [administrative](#input\_administrative) | Whether this stack can manage other stacks | `bool` | `false` | no |
 | <a name="input_administrative_stack_drift_detection_enabled"></a> [administrative\_stack\_drift\_detection\_enabled](#input\_administrative\_stack\_drift\_detection\_enabled) | Flag to enable/disable administrative stack drift detection | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,8 @@ module "stacks" {
   # lookup and use the worker pool ID from the map.
   # Otherwise, use `var.worker_pool_id`.
   worker_pool_id = try(var.worker_pool_name_id_map[each.value.settings.spacelift.worker_pool_name], var.worker_pool_id)
+
+  additional_mounted_files = try(each.value.settings.spacelift.additional_mounted_files, null) != null ? each.value.settings.spacelift.additional_mounted_files : var.additional_mounted_files
 }
 
 # `administrative` policies are always attached to the `administrative` stack

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -125,6 +125,15 @@ resource "spacelift_mounted_file" "stack_config" {
   write_only    = false
 }
 
+resource "spacelift_mounted_file" "additional" {
+  for_each = var.enabled ? var.additional_mounted_files : {}
+
+  stack_id      = spacelift_stack.default[0].id
+  relative_path = each.value.relative_path
+  content       = each.value.content
+  write_only    = lookup(each.value, "write_only", false)
+}
+
 resource "spacelift_environment_variable" "stack_name" {
   count = var.enabled ? 1 : 0
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -310,3 +310,9 @@ variable "description" {
   description = "Specify description of stack"
   default     = null
 }
+
+variable "additional_mounted_files" {
+  type        = map(any)
+  description = "Add additional mounted files where the values of each key are `relative_path`, `content`, and optional `write_only` which defaults to `false`."
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -356,3 +356,9 @@ variable "stack_context_variables" {
   description = "Map of variables to create a global context attached to each stack"
   default     = {}
 }
+
+variable "additional_mounted_files" {
+  type        = map(any)
+  description = "Add additional mounted files where the values of each key are `relative_path`, `content`, and optional `write_only` which defaults to `false`."
+  default     = {}
+}


### PR DESCRIPTION
## what
* Add `additional_mounted_files`

## why
* Add `ssh` or `.netrc` for external module usage on public workers
* Possibly add additional files

## Alternatives considered

- Using spacelift private module registry but this requires everyone use API creds locally OR use non-spacelift module source locally and then in the spacelift stack's `before_init` hook swap the source from non-spacelift to spacelift private registry source
- pure `before_init` hook that retrieves secret

## references
* https://docs.spacelift.io/vendors/terraform/external-modules

