### PR TITLE
Admin stack assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,39 +170,39 @@ Here is an example of using this module:
 We use YAML for the configuration files in order to separate configuration settings from business logic. It's also a portable format that can be used across multiple tools. Our convention is to name files by `$env-$stage.yaml` (e.g. `ue2-testing.yaml`), so for example an `$env` could be `ue2` (for `us-east-2`) and the `$stage` might be `testing`. Workspace names are derived from the `$env-$stage-$component`, which looks like  `ue2-testing-eks`.
 
 ```yaml
+# These are variables assigned to all component stacks
+vars:
+  my_global_var: value1
+
 # Components are all the top-level root modules
 components:
-  # Globals are exported as TF_VAR_... environment variables in every workspace
-  globals:
-    # Used to determine the name of the workspace (e.g. the 'testing' in 'ue2-testing')
-    stage: testing
-    # Used to determine the name of the workspace (e.g. the 'ue2' in 'ue2-testing')
-    environment: ue2
-  # The configuration file format is designed to be used across multiple tools.
-  # All terraform components should be listed under this section.
   terraform:
     # List one or more Terraform components here
     first-component:
-      # Controls whether or not this workspace should be created
-      # NOTE: If set to 'false', you cannot reference this workspace via `triggers` in another workspace!
-      workspace_enabled: true
-      # Override the version of Terraform for this workspace (defaults to the latest in Spacelift)
-      terraform_version: 0.13.4
-      # Controls the `auto_apply` setting within this workspace
-      auto_apply: true
-      # Add extra 'Run Triggers' to this workspace, beyond the parent workspace, which is created by default
-      # These triggers mean this component workspace will be automatically planned if any of these workspaces are applied.
-      triggers:
-        - uw2-testing-example2
-        - gbl-root-example1
+      settings:
+        spacelift:
+          # Controls whether or not this workspace should be created
+          # NOTE: If set to 'false', you cannot reference this workspace via `triggers` in another workspace!
+          workspace_enabled: true
+          # Override the version of Terraform for this workspace (defaults to the latest in Spacelift)
+          terraform_version: 0.13.4
+          # Controls the `auto_apply` setting within this workspace
+          auto_apply: true
+          # Add extra 'Run Triggers' to this workspace, beyond the parent workspace, which is created by default
+          # These triggers mean this component workspace will be automatically planned if any of these workspaces are applied.
+          triggers:
+            - uw2-testing-example2
+            - gbl-root-example1
       # Set the Terraform input variable values for this component. Complex types like maps and lists are supported.
       vars:
         my_input_var: "Hello world! This is a value that needs to be passed to my `first-component` Terraform component."
     # Every component should be uniquely named and correspond to a folder in the `components/` directory
     second-component:
-      workspace_enabled: true
-      # Specify a custom component folder (defalts to the component name if not specified)
-      custom_component_folder: my-custom-component-folder
+      settings:
+        spacelift:
+          workspace_enabled: true
+          # Specify a custom component folder (defalts to the component name if not specified)
+          custom_component_folder: my-custom-component-folder
       vars:
         my_input_var: "Hello world! This is another example!"
 ```

--- a/README.md
+++ b/README.md
@@ -182,17 +182,11 @@ components:
       settings:
         spacelift:
           # Controls whether or not this workspace should be created
-          # NOTE: If set to 'false', you cannot reference this workspace via `triggers` in another workspace!
           workspace_enabled: true
           # Override the version of Terraform for this workspace (defaults to the latest in Spacelift)
           terraform_version: 1.3.3
           # Controls the `auto_apply` setting within this workspace
           auto_apply: true
-          # Add extra 'Run Triggers' to this workspace, beyond the parent workspace, which is created by default
-          # These triggers mean this component workspace will be automatically planned if any of these workspaces are applied.
-          triggers:
-            - uw2-testing-example2
-            - gbl-root-example1
       # Set the Terraform input variable values for this component. Complex types like maps and lists are supported.
       vars:
         my_input_var: "Hello world! This is a value that needs to be passed to my `first-component` Terraform component."

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ components:
           # NOTE: If set to 'false', you cannot reference this workspace via `triggers` in another workspace!
           workspace_enabled: true
           # Override the version of Terraform for this workspace (defaults to the latest in Spacelift)
-          terraform_version: 0.13.4
+          terraform_version: 1.3.3
           # Controls the `auto_apply` setting within this workspace
           auto_apply: true
           # Add extra 'Run Triggers' to this workspace, beyond the parent workspace, which is created by default

--- a/README.yaml
+++ b/README.yaml
@@ -158,39 +158,39 @@ examples: |-
   We use YAML for the configuration files in order to separate configuration settings from business logic. It's also a portable format that can be used across multiple tools. Our convention is to name files by `$env-$stage.yaml` (e.g. `ue2-testing.yaml`), so for example an `$env` could be `ue2` (for `us-east-2`) and the `$stage` might be `testing`. Workspace names are derived from the `$env-$stage-$component`, which looks like  `ue2-testing-eks`.
 
   ```yaml
+  # These are variables assigned to all component stacks
+  vars:
+    my_global_var: value1
+
   # Components are all the top-level root modules
   components:
-    # Globals are exported as TF_VAR_... environment variables in every workspace
-    globals:
-      # Used to determine the name of the workspace (e.g. the 'testing' in 'ue2-testing')
-      stage: testing
-      # Used to determine the name of the workspace (e.g. the 'ue2' in 'ue2-testing')
-      environment: ue2
-    # The configuration file format is designed to be used across multiple tools.
-    # All terraform components should be listed under this section.
     terraform:
       # List one or more Terraform components here
       first-component:
-        # Controls whether or not this workspace should be created
-        # NOTE: If set to 'false', you cannot reference this workspace via `triggers` in another workspace!
-        workspace_enabled: true
-        # Override the version of Terraform for this workspace (defaults to the latest in Spacelift)
-        terraform_version: 0.13.4
-        # Controls the `auto_apply` setting within this workspace
-        auto_apply: true
-        # Add extra 'Run Triggers' to this workspace, beyond the parent workspace, which is created by default
-        # These triggers mean this component workspace will be automatically planned if any of these workspaces are applied.
-        triggers:
-          - uw2-testing-example2
-          - gbl-root-example1
+        settings:
+          spacelift:
+            # Controls whether or not this workspace should be created
+            # NOTE: If set to 'false', you cannot reference this workspace via `triggers` in another workspace!
+            workspace_enabled: true
+            # Override the version of Terraform for this workspace (defaults to the latest in Spacelift)
+            terraform_version: 0.13.4
+            # Controls the `auto_apply` setting within this workspace
+            auto_apply: true
+            # Add extra 'Run Triggers' to this workspace, beyond the parent workspace, which is created by default
+            # These triggers mean this component workspace will be automatically planned if any of these workspaces are applied.
+            triggers:
+              - uw2-testing-example2
+              - gbl-root-example1
         # Set the Terraform input variable values for this component. Complex types like maps and lists are supported.
         vars:
           my_input_var: "Hello world! This is a value that needs to be passed to my `first-component` Terraform component."
       # Every component should be uniquely named and correspond to a folder in the `components/` directory
       second-component:
-        workspace_enabled: true
-        # Specify a custom component folder (defalts to the component name if not specified)
-        custom_component_folder: my-custom-component-folder
+        settings:
+          spacelift:
+            workspace_enabled: true
+            # Specify a custom component folder (defalts to the component name if not specified)
+            custom_component_folder: my-custom-component-folder
         vars:
           my_input_var: "Hello world! This is another example!"
   ```

--- a/README.yaml
+++ b/README.yaml
@@ -173,7 +173,7 @@ examples: |-
             # NOTE: If set to 'false', you cannot reference this workspace via `triggers` in another workspace!
             workspace_enabled: true
             # Override the version of Terraform for this workspace (defaults to the latest in Spacelift)
-            terraform_version: 0.13.4
+            terraform_version: 1.3.3
             # Controls the `auto_apply` setting within this workspace
             auto_apply: true
             # Add extra 'Run Triggers' to this workspace, beyond the parent workspace, which is created by default

--- a/README.yaml
+++ b/README.yaml
@@ -170,17 +170,11 @@ examples: |-
         settings:
           spacelift:
             # Controls whether or not this workspace should be created
-            # NOTE: If set to 'false', you cannot reference this workspace via `triggers` in another workspace!
             workspace_enabled: true
             # Override the version of Terraform for this workspace (defaults to the latest in Spacelift)
             terraform_version: 1.3.3
             # Controls the `auto_apply` setting within this workspace
             auto_apply: true
-            # Add extra 'Run Triggers' to this workspace, beyond the parent workspace, which is created by default
-            # These triggers mean this component workspace will be automatically planned if any of these workspaces are applied.
-            triggers:
-              - uw2-testing-example2
-              - gbl-root-example1
         # Set the Terraform input variable values for this component. Complex types like maps and lists are supported.
         vars:
           my_input_var: "Hello world! This is a value that needs to be passed to my `first-component` Terraform component."

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ locals {
     for k, v in module.spacelift_config.spacelift_stacks :
     k => v
     if
+    lookup(v.settings.spacelift, "admin_stack", null) != null ? v.settings.spacelift.admin_stack == data.spacelift_current_stack.administrative.id :
     (lookup(var.context_filters, "namespaces", null) == null || contains(lookup(var.context_filters, "namespaces", [lookup(v.vars, "namespace", "")]), lookup(v.vars, "namespace", ""))) &&
     (lookup(var.context_filters, "tenants", null) == null || contains(lookup(var.context_filters, "tenants", [lookup(v.vars, "tenant", "")]), lookup(v.vars, "tenant", ""))) &&
     (lookup(var.context_filters, "environments", null) == null || contains(lookup(var.context_filters, "environments", [lookup(v.vars, "environment", "")]), lookup(v.vars, "environment", ""))) &&
@@ -143,9 +144,7 @@ module "stacks" {
 
 # `administrative` policies are always attached to the `administrative` stack
 # `spacelift_current_stack` is the administrative stack that manages all other infrastructure stacks
-data "spacelift_current_stack" "administrative" {
-  count = var.external_execution ? 0 : 1
-}
+data "spacelift_current_stack" "administrative" {}
 
 # global administrative trigger policy that allows us to trigger a stack right after it gets created
 resource "spacelift_policy" "trigger_administrative" {
@@ -161,13 +160,13 @@ resource "spacelift_policy_attachment" "trigger_administrative" {
   count = var.external_execution || var.administrative_trigger_policy_enabled == false ? 0 : 1
 
   policy_id = join("", spacelift_policy.trigger_administrative.*.id)
-  stack_id  = data.spacelift_current_stack.administrative[0].id
+  stack_id  = data.spacelift_current_stack.administrative.id
 }
 
 resource "spacelift_drift_detection" "drift_detection_administrative" {
   count = var.external_execution || var.administrative_stack_drift_detection_enabled == false ? 0 : 1
 
-  stack_id  = data.spacelift_current_stack.administrative[0].id
+  stack_id  = data.spacelift_current_stack.administrative.id
   reconcile = var.administrative_stack_drift_detection_reconcile
   schedule  = var.administrative_stack_drift_detection_schedule
 }

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ locals {
     k => v
     if
     # NOTE: This logic is still being tested/developed.. I should have it finalized in this PR shortly.
-    lookup(v.settings.spacelift, "admin_stack", null) != null && ! var.external_execution ? v.settings.spacelift.admin_stack == data.spacelift_current_stack[0].administrative.id :
+    lookup(v.settings.spacelift, "admin_stack", null) != null && ! var.external_execution ? v.settings.spacelift.admin_stack == data.spacelift_current_stack.administrative[0].id :
     (lookup(var.context_filters, "namespaces", null) == null || contains(lookup(var.context_filters, "namespaces", [lookup(v.vars, "namespace", "")]), lookup(v.vars, "namespace", ""))) &&
     (lookup(var.context_filters, "tenants", null) == null || contains(lookup(var.context_filters, "tenants", [lookup(v.vars, "tenant", "")]), lookup(v.vars, "tenant", ""))) &&
     (lookup(var.context_filters, "environments", null) == null || contains(lookup(var.context_filters, "environments", [lookup(v.vars, "environment", "")]), lookup(v.vars, "environment", ""))) &&


### PR DESCRIPTION
## what
* Adding support for new `admin_stack` setting that will allow a stack to be pinned to a specific admin stack

## why
* This allows us to group stacks into smaller sets in any arbitrary pattern.

## notes
* When using this new feature, it's best to have a global default defined, and then override the global default within each component configuration