### PR TITLE
Filter components by tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,13 @@ locals {
     (lookup(var.context_filters, "namespaces", null) == null || contains(lookup(var.context_filters, "namespaces", [lookup(v.vars, "namespace", "")]), lookup(v.vars, "namespace", ""))) &&
     (lookup(var.context_filters, "tenants", null) == null || contains(lookup(var.context_filters, "tenants", [lookup(v.vars, "tenant", "")]), lookup(v.vars, "tenant", ""))) &&
     (lookup(var.context_filters, "environments", null) == null || contains(lookup(var.context_filters, "environments", [lookup(v.vars, "environment", "")]), lookup(v.vars, "environment", ""))) &&
-    (lookup(var.context_filters, "stages", null) == null || contains(lookup(var.context_filters, "stages", [lookup(v.vars, "stage", "")]), lookup(v.vars, "stage", "")))
+    (lookup(var.context_filters, "stages", null) == null || contains(lookup(var.context_filters, "stages", [lookup(v.vars, "stage", "")]), lookup(v.vars, "stage", ""))) &&
+    (
+      lookup(var.context_filters, "tags", null) == null || lookup(v.vars, tags, null) == null || contains([
+        for k, v in lookup(var.context_filters, "tags", {}):
+        lookup(lookup(v.vars, "tags", {}), k, null) == v
+      ]), true)
+    )
   }
 
   # Find Rego policies defined in YAML config in all stacks


### PR DESCRIPTION
## what
* Filter components by tags

## why
* Allow filtering by generic tags so we can filter admin stacks by team tag for example.

## references
* Closes https://github.com/cloudposse/terraform-spacelift-cloud-infrastructure-automation/issues/123

