### PR TITLE
Update "OPA Policy Tests" GitHub action

### DIFF
--- a/.github/workflows/policy-tests.yml
+++ b/.github/workflows/policy-tests.yml
@@ -1,6 +1,8 @@
-name: Policy Tests
+name: OPA Policy Tests
 
 on:
+  workflow_dispatch:
+
   pull_request:
     paths:
       - '.github/workflows/policy-tests.yml' ## self-trigger
@@ -10,21 +12,24 @@ jobs:
   opa:
     name: opa-tests
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
-    - name: Run opa tests
-      uses: b4b4r07/action-opa@master
+      uses: actions/checkout@v2
+
+    - name: Run OPA tests
+      uses: cloudposse/action-opa@master
       with:
         coverage: 40%
         files: 'catalog/policies/**'
       id: opa
-    - name: Post opa command result to GitHub comment
+
+    - name: Post OPA test results to GitHub comment
       uses: b4b4r07/action-github-comment@master
       if: steps.opa.outputs.result
       with:
         body: |
-          ## opa test result
+          ## OPA test results
           ```
           ${{ steps.opa.outputs.result }}
           ```


### PR DESCRIPTION
## what
* Update "OPA Policy Tests" GitHub action

## why
* `b4b4r07/action-opa` repo has a very old OPA version, and the repo has not been updated in many years
* We need the latest OPA version to use some new Rego functions for comparing list of strings in Spacelift Rego policies to make the policy evaluation much faster
* We forked the repo to https://github.com/cloudposse/action-opa and updated everything to the new versions including OPA

## references
* https://github.com/cloudposse/action-opa/pull/1
