### PR TITLE
Adding support for Spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Available targets:
 | [spacelift_policy.default](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy.trigger_administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy_attachment.trigger_administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy_attachment) | resource |
+| [spacelift_current_space.administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/data-sources/current_space) | data source |
 | [spacelift_current_stack.administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/data-sources/current_stack) | data source |
 
 ## Inputs
@@ -273,6 +274,7 @@ Available targets:
 | <a name="input_after_init"></a> [after\_init](#input\_after\_init) | List of after-init scripts | `list(string)` | `[]` | no |
 | <a name="input_after_perform"></a> [after\_perform](#input\_after\_perform) | List of after-perform scripts | `list(string)` | `[]` | no |
 | <a name="input_after_plan"></a> [after\_plan](#input\_after\_plan) | List of after-plan scripts | `list(string)` | `[]` | no |
+| <a name="input_attachment_space_id"></a> [attachment\_space\_id](#input\_attachment\_space\_id) | Specify the space ID for attachments (e.g. policies, contexts, etc.) | `string` | `"legacy"` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_autodeploy"></a> [autodeploy](#input\_autodeploy) | Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration) | `bool` | `false` | no |
 | <a name="input_aws_role_arn"></a> [aws\_role\_arn](#input\_aws\_role\_arn) | ARN of the AWS IAM role to assume and put its temporary credentials in the runtime environment | `string` | `null` | no |
@@ -328,6 +330,7 @@ Available targets:
 | <a name="input_stack_context_variables"></a> [stack\_context\_variables](#input\_stack\_context\_variables) | Map of variables to create a global context attached to each stack | `map(string)` | `{}` | no |
 | <a name="input_stack_deps_processing_enabled"></a> [stack\_deps\_processing\_enabled](#input\_stack\_deps\_processing\_enabled) | Boolean flag to enable/disable processing all stack dependencies in the provided stack | `bool` | `false` | no |
 | <a name="input_stack_destructor_enabled"></a> [stack\_destructor\_enabled](#input\_stack\_destructor\_enabled) | Flag to enable/disable the stack destructor to destroy the resources of a stack before deleting the stack itself | `bool` | `false` | no |
+| <a name="input_stacks_space_id"></a> [stacks\_space\_id](#input\_stacks\_space\_id) | Override the space ID for all stacks (unless the stack config has `dedicated_space` set to true). Otherwise, it will default to the admin stack's space. | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tag_filters"></a> [tag\_filters](#input\_tag\_filters) | A map of tags that will filter stack creation by the matching `tags` set in a component `vars` configuration. | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -31,6 +31,7 @@
 | [spacelift_policy.default](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy.trigger_administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) | resource |
 | [spacelift_policy_attachment.trigger_administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy_attachment) | resource |
+| [spacelift_current_space.administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/data-sources/current_space) | data source |
 | [spacelift_current_stack.administrative](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/data-sources/current_stack) | data source |
 
 ## Inputs
@@ -48,6 +49,7 @@
 | <a name="input_after_init"></a> [after\_init](#input\_after\_init) | List of after-init scripts | `list(string)` | `[]` | no |
 | <a name="input_after_perform"></a> [after\_perform](#input\_after\_perform) | List of after-perform scripts | `list(string)` | `[]` | no |
 | <a name="input_after_plan"></a> [after\_plan](#input\_after\_plan) | List of after-plan scripts | `list(string)` | `[]` | no |
+| <a name="input_attachment_space_id"></a> [attachment\_space\_id](#input\_attachment\_space\_id) | Specify the space ID for attachments (e.g. policies, contexts, etc.) | `string` | `"legacy"` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_autodeploy"></a> [autodeploy](#input\_autodeploy) | Autodeploy global setting for Spacelift stacks. This setting can be overidden in stack-level configuration) | `bool` | `false` | no |
 | <a name="input_aws_role_arn"></a> [aws\_role\_arn](#input\_aws\_role\_arn) | ARN of the AWS IAM role to assume and put its temporary credentials in the runtime environment | `string` | `null` | no |
@@ -103,6 +105,7 @@
 | <a name="input_stack_context_variables"></a> [stack\_context\_variables](#input\_stack\_context\_variables) | Map of variables to create a global context attached to each stack | `map(string)` | `{}` | no |
 | <a name="input_stack_deps_processing_enabled"></a> [stack\_deps\_processing\_enabled](#input\_stack\_deps\_processing\_enabled) | Boolean flag to enable/disable processing all stack dependencies in the provided stack | `bool` | `false` | no |
 | <a name="input_stack_destructor_enabled"></a> [stack\_destructor\_enabled](#input\_stack\_destructor\_enabled) | Flag to enable/disable the stack destructor to destroy the resources of a stack before deleting the stack itself | `bool` | `false` | no |
+| <a name="input_stacks_space_id"></a> [stacks\_space\_id](#input\_stacks\_space\_id) | Override the space ID for all stacks (unless the stack config has `dedicated_space` set to true). Otherwise, it will default to the admin stack's space. | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tag_filters"></a> [tag\_filters](#input\_tag\_filters) | A map of tags that will filter stack creation by the matching `tags` set in a component `vars` configuration. | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -71,10 +71,10 @@ module "stacks" {
   space_id = coalesce(var.stacks_space_id, try(data.spacelift_current_space.administrative[0].id, "legacy"))
 
   enabled                   = each.value.enabled
-  dedicated_space_enabled           = try(each.value.settings.spacelift.dedicated_space_enabled, false)
+  dedicated_space_enabled   = try(each.value.settings.spacelift.dedicated_space_enabled, false)
   space_name                = try(each.value.settings.spacelift.space_name, null)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
-  inherit_entities         = try(each.value.settings.spacelift.space_inheritance, false)
+  inherit_entities          = try(each.value.settings.spacelift.space_inheritance, false)
   stack_name                = each.key
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "spacelift_policy" "default" {
   name = format("%s %s Policy", upper(split(".", each.key)[0]), title(replace(split(".", each.key)[1], "-", " ")))
   body = file(format("%s/%s/%s.rego", path.module, var.policies_path, each.key))
 
-  space_id = var.use_spaces ? var.space_id : null
+  space_id = var.space_id
 }
 
 # Convert infrastructure stacks from YAML configs into Spacelift stacks
@@ -60,7 +60,7 @@ resource "spacelift_policy" "custom" {
   name = format("%s %s Policy", upper(split(".", each.key)[0]), title(replace(split(".", each.key)[1], "-", " ")))
   body = file(format("%s/%s.rego", var.policies_by_name_path, each.key))
 
-  space_id = var.use_spaces ? var.space_id : null
+  space_id = var.space_id
 }
 
 module "stacks" {
@@ -166,7 +166,7 @@ resource "spacelift_policy" "trigger_administrative" {
   name = "Global Administrative Trigger Policy"
   body = file(format("%s/%s/trigger.administrative.rego", path.module, var.policies_path))
 
-  space_id = var.use_spaces ? var.space_id : null
+  space_id = var.space_id
 }
 
 # Attach the global trigger policy to the current administrative stack
@@ -191,7 +191,7 @@ resource "spacelift_context" "default" {
   description = var.stack_context_description
   name        = var.stack_context_name
 
-  space_id = var.use_spaces ? var.space_id : null
+  space_id = var.space_id
 }
 
 resource "spacelift_environment_variable" "default" {

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,7 @@ module "stacks" {
 
   enabled                   = each.value.enabled
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)
+  space_name                = try(each.value.settings.spacelift.space_name, null)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
   space_inheritance         = try(each.value.settings.spacelift.space_inheritance, false)
   stack_name                = each.key

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ module "stacks" {
 
   for_each = local.spacelift_stacks
 
-  space_id = try(data.spacelift_current_space.administrative[0].id, null)
+  space_id = try(var.stacks_space_id, data.spacelift_current_space.administrative[0].id, null)
 
   enabled                   = each.value.enabled
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,8 @@ module "stacks" {
 
   for_each = local.spacelift_stacks
 
+  space_id = var.space_id
+
   enabled                   = each.value.enabled
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ module "stacks" {
   enabled                   = each.value.enabled
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
+  space_inheritance         = try(each.value.settings.spacelift.space_inheritance, false)
   stack_name                = each.key
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component

--- a/main.tf
+++ b/main.tf
@@ -200,6 +200,4 @@ resource "spacelift_environment_variable" "default" {
   name       = each.key
   value      = each.value
   write_only = false
-
-  space_id = var.use_spaces ? var.space_id : null
 }

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ module "stacks" {
   space_id = coalesce(var.stacks_space_id, try(data.spacelift_current_space.administrative[0].id, "legacy"))
 
   enabled                   = each.value.enabled
-  dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)
+  dedicated_space_enabled           = try(each.value.settings.spacelift.dedicated_space_enabled, false)
   space_name                = try(each.value.settings.spacelift.space_name, null)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
   inherit_entities         = try(each.value.settings.spacelift.space_inheritance, false)

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ module "stacks" {
   dedicated_space_enabled   = try(each.value.settings.spacelift.dedicated_space_enabled, false)
   space_name                = try(each.value.settings.spacelift.space_name, null)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
-  inherit_entities          = try(each.value.settings.spacelift.space_inheritance, false)
+  inherit_entities          = try(each.value.settings.spacelift.inherit_entities, false)
   stack_name                = each.key
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "spacelift_policy" "default" {
   name = format("%s %s Policy", upper(split(".", each.key)[0]), title(replace(split(".", each.key)[1], "-", " ")))
   body = file(format("%s/%s/%s.rego", path.module, var.policies_path, each.key))
 
-  space_id = var.space_id
+  space_id = var.attachment_space_id
 }
 
 # Convert infrastructure stacks from YAML configs into Spacelift stacks
@@ -60,7 +60,7 @@ resource "spacelift_policy" "custom" {
   name = format("%s %s Policy", upper(split(".", each.key)[0]), title(replace(split(".", each.key)[1], "-", " ")))
   body = file(format("%s/%s.rego", var.policies_by_name_path, each.key))
 
-  space_id = var.space_id
+  space_id = var.attachment_space_id
 }
 
 module "stacks" {
@@ -68,7 +68,7 @@ module "stacks" {
 
   for_each = local.spacelift_stacks
 
-  space_id = var.space_id
+  space_id = try(data.spacelift_current_space.administrative[0].id, null)
 
   enabled                   = each.value.enabled
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)
@@ -170,7 +170,7 @@ resource "spacelift_policy" "trigger_administrative" {
   name = "Global Administrative Trigger Policy"
   body = file(format("%s/%s/trigger.administrative.rego", path.module, var.policies_path))
 
-  space_id = var.space_id
+  space_id = var.attachment_space_id
 }
 
 # Attach the global trigger policy to the current administrative stack
@@ -195,7 +195,7 @@ resource "spacelift_context" "default" {
   description = var.stack_context_description
   name        = var.stack_context_name
 
-  space_id = var.space_id
+  space_id = var.attachment_space_id
 }
 
 resource "spacelift_environment_variable" "default" {
@@ -204,4 +204,12 @@ resource "spacelift_environment_variable" "default" {
   name       = each.key
   value      = each.value
   write_only = false
+}
+
+data "spacelift_current_stack" "administrative" {
+  count = var.external_execution ? 0 : 1
+}
+
+data "spacelift_current_space" "administrative" {
+  count = var.external_execution ? 0 : 1
 }

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,8 @@ resource "spacelift_policy" "default" {
   type = upper(split(".", each.key)[0])
   name = format("%s %s Policy", upper(split(".", each.key)[0]), title(replace(split(".", each.key)[1], "-", " ")))
   body = file(format("%s/%s/%s.rego", path.module, var.policies_path, each.key))
+
+  space_id = var.use_spaces ? var.space_id : null
 }
 
 # Convert infrastructure stacks from YAML configs into Spacelift stacks
@@ -57,6 +59,8 @@ resource "spacelift_policy" "custom" {
   type = upper(split(".", each.key)[0])
   name = format("%s %s Policy", upper(split(".", each.key)[0]), title(replace(split(".", each.key)[1], "-", " ")))
   body = file(format("%s/%s.rego", var.policies_by_name_path, each.key))
+
+  space_id = var.use_spaces ? var.space_id : null
 }
 
 module "stacks" {
@@ -65,6 +69,7 @@ module "stacks" {
   for_each = local.spacelift_stacks
 
   enabled                   = each.value.enabled
+  dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)
   stack_name                = each.key
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component
@@ -160,6 +165,8 @@ resource "spacelift_policy" "trigger_administrative" {
   type = "TRIGGER"
   name = "Global Administrative Trigger Policy"
   body = file(format("%s/%s/trigger.administrative.rego", path.module, var.policies_path))
+
+  space_id = var.use_spaces ? var.space_id : null
 }
 
 # Attach the global trigger policy to the current administrative stack
@@ -183,6 +190,8 @@ resource "spacelift_context" "default" {
 
   description = var.stack_context_description
   name        = var.stack_context_name
+
+  space_id = var.use_spaces ? var.space_id : null
 }
 
 resource "spacelift_environment_variable" "default" {
@@ -191,4 +200,6 @@ resource "spacelift_environment_variable" "default" {
   name       = each.key
   value      = each.value
   write_only = false
+
+  space_id = var.use_spaces ? var.space_id : null
 }

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ module "stacks" {
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)
   space_name                = try(each.value.settings.spacelift.space_name, null)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
-  space_inheritance         = try(each.value.settings.spacelift.space_inheritance, false)
+  inherit_entities         = try(each.value.settings.spacelift.space_inheritance, false)
   stack_name                = each.key
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component

--- a/main.tf
+++ b/main.tf
@@ -206,10 +206,6 @@ resource "spacelift_environment_variable" "default" {
   write_only = false
 }
 
-data "spacelift_current_stack" "administrative" {
-  count = var.external_execution ? 0 : 1
-}
-
 data "spacelift_current_space" "administrative" {
   count = var.external_execution ? 0 : 1
 }

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ module "stacks" {
 
   for_each = local.spacelift_stacks
 
-  space_id = try(var.stacks_space_id, data.spacelift_current_space.administrative[0].id, null)
+  space_id = coalesce(var.stacks_space_id, try(data.spacelift_current_space.administrative[0].id, null), "legacy")
 
   enabled                   = each.value.enabled
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ module "stacks" {
 
   for_each = local.spacelift_stacks
 
-  space_id = coalesce(var.stacks_space_id, try(data.spacelift_current_space.administrative[0].id, null), "legacy")
+  space_id = coalesce(var.stacks_space_id, try(data.spacelift_current_space.administrative[0].id, "legacy"))
 
   enabled                   = each.value.enabled
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,7 @@ module "stacks" {
 
   enabled                   = each.value.enabled
   dedicated_space           = try(each.value.settings.spacelift.dedicated_space, false)
+  parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
   stack_name                = each.key
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -223,4 +223,6 @@ resource "spacelift_space" "default" {
 
   name            = var.component_name
   parent_space_id = var.parent_space_id
+
+  inherit_entities = var.space_inheritance
 }

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -222,5 +222,5 @@ resource "spacelift_space" "default" {
   count = var.dedicated_space ? 1 : 0
 
   name            = var.component_name
-  parent_space_id = var.space_id
+  parent_space_id = "root""
 }

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -12,7 +12,7 @@ locals {
 resource "spacelift_stack" "default" {
   count = var.enabled ? 1 : 0
 
-  space_id = coalesce(try(spacelift_space.default[0].id, null), var.space_id)
+  space_id = try(spacelift_space.default[0].id, var.space_id)
 
   name                 = var.stack_name
   description          = var.description

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -221,8 +221,9 @@ resource "spacelift_context_attachment" "attachment" {
 resource "spacelift_space" "default" {
   count = var.dedicated_space ? 1 : 0
 
-  name            = var.component_name
-  parent_space_id = var.parent_space_id
-
+  name             = var.component_name
+  parent_space_id  = var.parent_space_id
   inherit_entities = var.space_inheritance
+  description      = var.description
+  labels           = var.labels
 }

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -221,7 +221,7 @@ resource "spacelift_context_attachment" "attachment" {
 resource "spacelift_space" "default" {
   count = var.dedicated_space ? 1 : 0
 
-  name             = var.component_name
+  name             = coalesce(var.space_name, var.component_name)
   parent_space_id  = var.parent_space_id
   inherit_entities = var.space_inheritance
   description      = var.description

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -219,7 +219,7 @@ resource "spacelift_context_attachment" "attachment" {
 }
 
 resource "spacelift_space" "default" {
-  count = var.dedicated_space ? 1 : 0
+  count = var.dedicated_space_enabled ? 1 : 0
 
   name             = coalesce(var.space_name, var.component_name)
   parent_space_id  = var.parent_space_id

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -223,7 +223,7 @@ resource "spacelift_space" "default" {
 
   name             = coalesce(var.space_name, var.component_name)
   parent_space_id  = var.parent_space_id
-  inherit_entities = var.space_inheritance
+  inherit_entities = var.inherit_entities
   description      = var.description
   labels           = var.labels
 }

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -12,7 +12,7 @@ locals {
 resource "spacelift_stack" "default" {
   count = var.enabled ? 1 : 0
 
-  space_id = try(spacelift_space.default[0].id, null)
+  space_id = coalesce(try(spacelift_space.default[0].id, null), var.space_id)
 
   name                 = var.stack_name
   description          = var.description

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -222,5 +222,5 @@ resource "spacelift_space" "default" {
   count = var.dedicated_space ? 1 : 0
 
   name            = var.component_name
-  parent_space_id = "root""
+  parent_space_id = var.parent_space_id
 }

--- a/modules/stack/main.tf
+++ b/modules/stack/main.tf
@@ -12,6 +12,8 @@ locals {
 resource "spacelift_stack" "default" {
   count = var.enabled ? 1 : 0
 
+  space_id = try(spacelift_space.default[0].id, null)
+
   name                 = var.stack_name
   description          = var.description
   administrative       = var.administrative
@@ -214,4 +216,11 @@ resource "spacelift_context_attachment" "attachment" {
   context_id = each.key
   stack_id   = spacelift_stack.default[0].id
   priority   = each.value
+}
+
+resource "spacelift_space" "default" {
+  count = var.dedicated_space ? 1 : 0
+
+  name            = var.component_name
+  parent_space_id = var.space_id
 }

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -313,7 +313,7 @@ variable "description" {
 
 variable "dedicated_space" {
   type        = bool
-  description = "If enabled, create a new space for the admin stack in Spacelift. All child stacks will also be a member of the new space."
+  description = "If enabled, create a new space for the admin stack in Spacelift. All child stacks will also be members of the new space."
   default     = false
 }
 

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -311,7 +311,7 @@ variable "description" {
   default     = null
 }
 
-variable "dedicated_space" {
+variable "dedicated_space_enabled" {
   type        = bool
   description = "If enabled, create a new space for the admin stack in Spacelift. All child stacks will also be members of the new space."
   default     = false

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -323,7 +323,7 @@ variable "parent_space_id" {
   default     = null
 }
 
-variable "space_inheritance" {
+variable "inherit_entities" {
   type        = bool
   description = "If creating a dedicated space for this stack, specify whether or not to inherit entities."
   default     = false

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -316,3 +316,9 @@ variable "dedicated_space" {
   description = "If enabled, create a new space for the admin stack in Spacelift. All child stacks will also be a member of the new space."
   default     = false
 }
+
+variable "parent_space_id" {
+  type        = string
+  description = "If creating a dedicated space for this stack, specify the ID of the parent space in Spacelift."
+  default     = null
+}

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -310,3 +310,9 @@ variable "description" {
   description = "Specify description of stack"
   default     = null
 }
+
+variable "dedicated_space" {
+  type        = bool
+  description = "If enabled, create a new space for the admin stack in Spacelift. All child stacks will also be a member of the new space."
+  default     = false
+}

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -328,3 +328,9 @@ variable "space_inheritance" {
   description = "If creating a dedicated space for this stack, specify whether or not to inherit entities."
   default     = false
 }
+
+variable "space_id" {
+  type        = string
+  description = "Place the stack in the specified space_id."
+  default     = "legacy"
+}

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -322,3 +322,9 @@ variable "parent_space_id" {
   description = "If creating a dedicated space for this stack, specify the ID of the parent space in Spacelift."
   default     = null
 }
+
+variable "space_inheritance" {
+  type        = bool
+  description = "If creating a dedicated space for this stack, specify whether or not to inherit entities."
+  default     = false
+}

--- a/modules/stack/variables.tf
+++ b/modules/stack/variables.tf
@@ -334,3 +334,9 @@ variable "space_id" {
   description = "Place the stack in the specified space_id."
   default     = "legacy"
 }
+
+variable "space_name" {
+  type        = string
+  description = "If using a dedicated space, override the name of the space (instead of using `component_name`)."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -363,8 +363,8 @@ variable "stack_context_variables" {
   default     = {}
 }
 
-variable "space_id" {
+variable "attachment_space_id" {
   type        = string
-  description = "Place the stack(s) in the specified space_id."
+  description = "Specify the space ID for attachments (e.g. policies, contexts, etc.)"
   default     = "legacy"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -368,3 +368,9 @@ variable "attachment_space_id" {
   description = "Specify the space ID for attachments (e.g. policies, contexts, etc.)"
   default     = "legacy"
 }
+
+variable "stacks_space_id" {
+  type        = string
+  description = "Override the space ID for all stacks (unless the stack config has `dedicated_space` set to true). Otherwise, it will default to the admin stack's space."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -363,14 +363,8 @@ variable "stack_context_variables" {
   default     = {}
 }
 
-variable "use_spaces" {
-  type        = bool
-  description = "If `true`, place the stack(s) in a Spacelift space (`root` by default)."
-  default     = false
-}
-
 variable "space_id" {
   type        = string
-  description = "If using spaces, place the stack(s) in the specified space_id."
-  default     = "root"
+  description = "Place the stack(s) in the specified space_id."
+  default     = "legacy"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -362,3 +362,15 @@ variable "stack_context_variables" {
   description = "Map of variables to create a global context attached to each stack"
   default     = {}
 }
+
+variable "use_spaces" {
+  type        = bool
+  description = "If `true`, place the stack(s) in a Spacelift space (`root` by default)."
+  default     = false
+}
+
+variable "space_id" {
+  type        = string
+  description = "If using spaces, place the stack(s) in the specified space_id."
+  default     = "root"
+}


### PR DESCRIPTION
### what?

* Ability to create a dedicated space for any stack via it's Spacelift settings (although it's primarily meant for admin stacks)
* Ability to override space id for attachments (policies, contexts, etc.) for when we need to put them in a space separate from the admin stack (e.g. `root`)
* Ability to override space id for stacks created by an admin stack (`stacks_space_id`)
* Ability to specify space inheritance
* Should default to `legacy` space everywhere so as to not break existing users who haven't migrated to spaces

### notes
* This was tested successfully w/ a CP client
* Also tested a legacy setup by running a plan on `cplive` and verifying nothing is broken

