### PR TITLE
Adding missing space_id parameter in new global administrator push po…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,8 @@ resource "spacelift_policy" "push_administrative" {
   type = "GIT_PUSH"
   name = "Global Administrative Push Policy"
   body = file(format("%s/%s/git_push.administrative.rego", path.module, var.policies_path))
+
+  space_id = var.attachment_space_id
 }
 
 # Attach the global git push policy to the current administrative stack


### PR DESCRIPTION
* This fixes an issue w/ the new administrative GIT_PUSH policy when using spaces (unless otherwise specified, it will be created in `legacy`, which is a problem for anyone using spaces!

