### PR TITLE
Allow overriding the display stack name using yaml

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ module "stacks" {
   space_name                = try(each.value.settings.spacelift.space_name, null)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
   inherit_entities          = try(each.value.settings.spacelift.inherit_entities, false)
-  stack_name                = each.key
+  stack_name                = try(each.value.settings.spacelift.stack_name, each.key)
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component
   component_vars            = each.value.vars


### PR DESCRIPTION
## what
- Allow overriding the display stack name using yaml

## why
- Some users want specific names due to prior documentation or readability.
- Using `stack_name_pattern` would override the spacelift stack slug which would recreate the stack which we do not want to do.
- By supplying `stack_name` we can retain the slug (avoid recreation) and change the display name to what we want

## references
N/A

