### PR TITLE
Add support for `settings.spacelift.ui_stack_name`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020-2022 Cloud Posse, LLC
+   Copyright 2020-2023 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2022 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2023 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ module "stacks" {
   space_name                = try(each.value.settings.spacelift.space_name, null)
   parent_space_id           = try(each.value.settings.spacelift.parent_space_id, null)
   inherit_entities          = try(each.value.settings.spacelift.inherit_entities, false)
-  stack_name                = try(each.value.settings.spacelift.stack_name, each.key)
+  stack_name                = try(each.value.settings.spacelift.ui_stack_name, try(each.value.settings.spacelift.stack_name, each.key))
   infrastructure_stack_name = each.value.stack
   component_name            = each.value.component
   component_vars            = each.value.vars


### PR DESCRIPTION
## what
* Add support for `settings.spacelift.ui_stack_name`

## why
* Allow overriding Spacelift stack names in Spacelift UI only
* `settings.spacelift.stack_name` is used to override Spacelift stack names both in terraform and Spacelift UI, while `settings.spacelift.ui_stack_name` is used to override stack names in Spacelift UI only


