### PR TITLE
Add a spacelift space_id override

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,10 @@ module "stacks" {
 
   for_each = local.spacelift_stacks
 
-  space_id = coalesce(var.stacks_space_id, try(data.spacelift_current_space.administrative[0].id, "legacy"))
+  space_id = coalesce(
+    try(each.value.settings.spacelift.space_id, var.stacks_space_id),
+    try(data.spacelift_current_space.administrative[0].id, "legacy"),
+  )
 
   enabled                   = each.value.enabled
   dedicated_space_enabled   = try(each.value.settings.spacelift.dedicated_space_enabled, false)


### PR DESCRIPTION
## what
* Add a spacelift space_id override

## why
* At the moment, we have an admin infra stack that creates an infra space. The admin infra stack also creates a spacelift-policy stack which requires the root space. This will allow the spacelift-policy stack to override the infra space to use the root space.

## references
N/A

