### PR TITLE
update policy based on new command ordering

### DIFF
--- a/catalog/policies/push.git_comment.rego
+++ b/catalog/policies/push.git_comment.rego
@@ -13,12 +13,12 @@ package spacelift
 
 track {
 	commented
-	contains(input.pull_request.comment, concat(" ", ["/spacelift", "deploy", input.stack.id]))
+	contains(input.pull_request.comment, concat(" ", ["/spacelift", input.stack.id, "deploy"]))
 }
 
 propose {
 	commented
-	contains(input.pull_request.comment, concat(" ", ["/spacelift", "preview", input.stack.id]))
+	contains(input.pull_request.comment, concat(" ", ["/spacelift", input.stack.id, "preview"]))
 }
 
 # Ignore if the event is not a comment
@@ -54,6 +54,6 @@ cancel[run.id] {
 
 # This is a random sample of 10% of the runs
 sample {
-  millis := round(input.request.timestamp_ns / 1e6)
-  millis % 100 <= 10
+	millis := round(input.request.timestamp_ns / 1e6)
+	millis % 100 <= 10
 }


### PR DESCRIPTION
## what

Update the order of comments from /spacelift {preview,deploy} [stackname] to /spacelift [stackname] {preview,deploy}

## why

When there are stacks whose ids are substrings of other stacks, both stacks were accidentally triggered because the spacelift policy uses contains(input.pull_request.comment, concat(" ", ["/spacelift", "preview", input.stack.id])) to match the comments from the Pull Request.

## references

[cloudposse/github-action-atmos-affected-trigger-spacelift](https://github.com/cloudposse/github-action-atmos-affected-trigger-spacelift/pull/26) PR
 