### PR TITLE
feat(spacelift-policy): add support for file paths

### DIFF
--- a/examples/spacelift-policy/fixtures.tfvars
+++ b/examples/spacelift-policy/fixtures.tfvars
@@ -22,3 +22,11 @@ catalog_policy_body_url = "https://raw.githubusercontent.com/cloudposse/terrafor
 catalog_policy_body_url_version = "master"
 
 catalog_policy_labels = ["test", "terraform", "spacelift", "catalog"]
+
+file_policy_name = "Test Filepath Policy"
+
+file_policy_type = "TRIGGER"
+
+file_policy_body_path = "../../catalog/policies/trigger.dependencies.rego"
+
+file_policy_labels = ["test", "terraform", "spacelift", "file", "path", "policy"]

--- a/examples/spacelift-policy/main.tf
+++ b/examples/spacelift-policy/main.tf
@@ -20,3 +20,13 @@ module "catalog_policy" {
   labels           = var.catalog_policy_labels
   space_id         = "root"
 }
+
+module "file_policy" {
+  source = "../../modules/spacelift-policy"
+
+  policy_name    = var.file_policy_name
+  type           = var.file_policy_type
+  body_file_path = var.file_policy_body_path
+  labels         = var.file_policy_labels
+  space_id       = "root"
+}

--- a/examples/spacelift-policy/variables.tf
+++ b/examples/spacelift-policy/variables.tf
@@ -36,3 +36,20 @@ variable "catalog_policy_labels" {
   type    = set(string)
   default = []
 }
+
+variable "file_policy_name" {
+  type        = string
+}
+
+variable "file_policy_type" {
+  type        = string
+}
+
+variable "file_policy_body_path" {
+  type        = string
+}
+
+variable "file_policy_labels" {
+  type    = set(string)
+  default     = []
+}

--- a/modules/spacelift-policy/main.tf
+++ b/modules/spacelift-policy/main.tf
@@ -1,10 +1,13 @@
 #provider "spacelift" {}
 
 locals {
-  enabled          = module.this.enabled
-  is_body_from_url = local.enabled && var.body_url != null
-  body_url         = local.is_body_from_url ? format(var.body_url, var.body_url_version) : null
-  body             = local.is_body_from_url ? data.http.this[0].response_body : var.body
+  enabled             = module.this.enabled
+  is_body_from_url    = local.enabled && var.body_url != null
+  is_body_from_file   = local.enabled && var.body_file_path != null
+  body_url            = local.is_body_from_url ? format(var.body_url, var.body_url_version) : null
+  body_from_url       = local.is_body_from_url ? data.http.this[0].response_body : null
+  body_from_file      = local.is_body_from_file ? file(var.body_file_path) : null
+  body                = coalesce(local.body_from_url, local.body_from_file, var.body)
 }
 
 resource "spacelift_policy" "this" {
@@ -18,13 +21,16 @@ resource "spacelift_policy" "this" {
 
   lifecycle {
     precondition {
-      condition     = var.body != null || var.body_url != null
-      error_message = "A policy body must be specified either with `var.body` or `var.body_url`."
+      condition     = var.body != null || var.body_url != null || var.body_file_path != null
+      error_message = "A policy body must be specified either with `var.body`, `var.body_url`, or `var.body_file_path`."
     }
 
     precondition {
-      condition     = (var.body != null && var.body_url == null) || (var.body == null && var.body_url != null)
-      error_message = "Only one of `var.body` and `var.body_url` should be specified."
+      condition     = (
+        var.body != null && var.body_url == null && var.body_file_path == null) || (
+        var.body == null && var.body_url != null && var.body_file_path == null) || (
+        var.body == null && var.body_url == null && var.body_file_path != null)
+      error_message = "Only one of `var.body`, `var.body_url`, or `var.body_file_path` should be specified."
     }
   }
 }

--- a/modules/spacelift-policy/variables.tf
+++ b/modules/spacelift-policy/variables.tf
@@ -21,6 +21,12 @@ variable "body_url_version" {
   default     = "master"
 }
 
+variable "body_file_path" {
+  description = "Path to the file containing the policy body"
+  type        = string
+  default     = null
+}
+
 variable "type" {
   type        = string
   description = "The type of the policy to create."


### PR DESCRIPTION
## what

- Adds support for using a local file path as the source of a Spacelift Rego policy

## why

- Policies are not always on a public URL.
- Having a lot of inline policies makes the file hard to manage, plus the code editor won't recognize the syntax because it's not in a .rego file
- Although this can be done on a case by case basis at the root module level, when there is a lot of policies, especially when certain policies uses an URL while others is inline and some uses local file path, it becomes messy. It's cleaner to have it at the module. 

