### PR TITLE
feat(spacelift-stack): replace administrative flag with spacelift_role_attachment

### DIFF
--- a/examples/spacelift-config-from-atmos-config/versions.tf
+++ b/examples/spacelift-config-from-atmos-config/versions.tf
@@ -2,5 +2,9 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 1.7.1, < 2.0.0"
+    }
   }
 }

--- a/examples/spacelift-config-from-atmos-config/versions.tf
+++ b/examples/spacelift-config-from-atmos-config/versions.tf
@@ -2,9 +2,5 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    utils = {
-      source  = "cloudposse/utils"
-      version = ">= 1.7.1, < 2.0.0"
-    }
   }
 }

--- a/examples/spacelift-config-from-atmos-config/versions.tf
+++ b/examples/spacelift-config-from-atmos-config/versions.tf
@@ -1,6 +1,8 @@
 terraform {
   required_version = ">= 0.13.0"
   required_providers {
+    # v1.32+ embeds Atmos v1.207+ which changed empty base_path resolution
+    # from CWD to git root, breaking callers that run from a subdirectory.
     utils = {
       source  = "cloudposse/utils"
       version = ">= 1.7.1, < 1.32.0"

--- a/examples/spacelift-config-from-atmos-config/versions.tf
+++ b/examples/spacelift-config-from-atmos-config/versions.tf
@@ -1,6 +1,9 @@
 terraform {
   required_version = ">= 0.13.0"
-
   required_providers {
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 1.7.1, < 1.32.0"
+    }
   }
 }

--- a/modules/spacelift-stack/main.tf
+++ b/modules/spacelift-stack/main.tf
@@ -22,7 +22,6 @@ resource "spacelift_stack" "this" {
 
   name                         = var.stack_name
   description                  = var.description
-  administrative               = var.administrative
   autodeploy                   = var.autodeploy
   autoretry                    = var.autoretry
   repository                   = var.repository
@@ -119,6 +118,19 @@ resource "spacelift_stack" "this" {
 # resources in the stack being deleted. Instead, this resource is always created, with var.stack_destructor_enabled
 # toggling its 'deactivated' attribute, which allows for the stack destructor functionality to be disabled. See:
 # https://github.com/spacelift-io/terraform-provider-spacelift/blob/master/spacelift/resource_stack_destructor.go
+data "spacelift_role" "admin" {
+  count = local.enabled && var.administrative ? 1 : 0
+  slug  = "space-admin"
+}
+
+resource "spacelift_role_attachment" "admin" {
+  count = local.enabled && var.administrative ? 1 : 0
+
+  stack_id = spacelift_stack.this[0].id
+  role_id  = data.spacelift_role.admin[0].id
+  space_id = var.space_id
+}
+
 resource "spacelift_stack_destructor" "this" {
   count = local.enabled ? 1 : 0
 

--- a/modules/spacelift-stack/variables.tf
+++ b/modules/spacelift-stack/variables.tf
@@ -1,6 +1,6 @@
 variable "administrative" {
   type        = bool
-  description = "Whether this stack can manage other stacks"
+  description = "The Spacelift API removed the administrative flag on June 1, 2026. This variable is retained for backward compatibility only — when true, a spacelift_role_attachment granting Space Admin on the stack's space is created instead."
   default     = false
 }
 

--- a/modules/spacelift-stack/versions.tf
+++ b/modules/spacelift-stack/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     spacelift = {
       source  = "spacelift-io/spacelift"
-      version = ">= 0.1.31"
+      version = ">= 1.37.0"
     }
   }
 }

--- a/modules/spacelift-stacks-from-atmos-config/main.tf
+++ b/modules/spacelift-stacks-from-atmos-config/main.tf
@@ -1,7 +1,7 @@
 # Convert infrastructure stacks from YAML configs into Spacelift stacks
 module "spacelift_config" {
   source  = "cloudposse/stack-config/yaml//modules/spacelift"
-  version = "1.8.0"
+  version = "2.0.0"
 
   stack_config_path_template = var.stack_config_path_template
 

--- a/modules/spacelift-stacks-from-atmos-config/main.tf
+++ b/modules/spacelift-stacks-from-atmos-config/main.tf
@@ -1,7 +1,7 @@
 # Convert infrastructure stacks from YAML configs into Spacelift stacks
 module "spacelift_config" {
   source  = "cloudposse/stack-config/yaml//modules/spacelift"
-  version = "2.0.0"
+  version = "1.8.0"
 
   stack_config_path_template = var.stack_config_path_template
 

--- a/modules/spacelift-stacks-from-atmos-config/versions.tf
+++ b/modules/spacelift-stacks-from-atmos-config/versions.tf
@@ -2,6 +2,8 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
+    # v1.32+ embeds Atmos v1.207+ which changed empty base_path resolution
+    # from CWD to git root, breaking callers that run from a subdirectory.
     utils = {
       source  = "cloudposse/utils"
       version = ">= 1.7.1, < 1.32.0"

--- a/modules/spacelift-stacks-from-atmos-config/versions.tf
+++ b/modules/spacelift-stacks-from-atmos-config/versions.tf
@@ -1,10 +1,5 @@
 terraform {
   required_version = ">= 0.13.0"
 
-  required_providers {
-    utils = {
-      source  = "cloudposse/utils"
-      version = ">= 1.7.1, < 2.0.0"
-    }
-  }
+  required_providers {}
 }

--- a/modules/spacelift-stacks-from-atmos-config/versions.tf
+++ b/modules/spacelift-stacks-from-atmos-config/versions.tf
@@ -1,5 +1,10 @@
 terraform {
   required_version = ">= 0.13.0"
 
-  required_providers {}
+  required_providers {
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 1.7.1, < 2.0.0"
+    }
+  }
 }

--- a/modules/spacelift-stacks-from-atmos-config/versions.tf
+++ b/modules/spacelift-stacks-from-atmos-config/versions.tf
@@ -1,5 +1,10 @@
 terraform {
   required_version = ">= 0.13.0"
 
-  required_providers {}
+  required_providers {
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 1.7.1, < 1.32.0"
+    }
+  }
 }


### PR DESCRIPTION
## what

- Removes `administrative = var.administrative` from the `spacelift_stack` resource — the Spacelift API removed this field on June 1, 2026; any stack with it set now fails on apply
- Adds `data "spacelift_role" "admin"` to resolve the `space-admin` built-in role ID by slug
- Adds `spacelift_role_attachment.admin` conditioned on `var.administrative == true`, granting Space Admin on the stack's own space — equivalent behavior to the removed flag
- Bumps Spacelift provider minimum from `>= 0.1.31` to `>= 1.37.0` (required for `spacelift_role_attachment` with `stack_id`)
- `var.administrative` is retained — callers passing `true` get a role attachment, callers passing `false` are unaffected
- Pins `cloudposse/utils` to `< 1.32.0` in `modules/spacelift-stacks-from-atmos-config` and the corresponding example — v1.32+ embeds Atmos v1.207+ which changed empty `base_path` resolution from CWD to git root, breaking the terratest setup where the example runs in a subdirectory

## why

- Spacelift removed the `administrative` flag from the `spacelift_stack` API on June 1, 2026. Every stack using this module with `administrative = true` is currently broken with: `could not update stack: the administrative flag is no longer supported on stacks; attach the Space admin role to the stack instead`
- Spacelift automatically backfilled `spacelift_role_attachment` (Space Admin) on previously-administrative stacks on June 1. Existing users must import those backfilled resources before applying to avoid a conflict error. Import ID format: `STACK/<ROLE_BINDING_ULID>`. IDs retrievable via GraphQL: `{ stack(id: "<stack-id>") { roleBindings { id } } }`
- The `cloudposse/utils` pin fixes a pre-existing test regression introduced when utils v1.32.0 shipped — unrelated to the administrative flag changes but blocking CI on this PR

## references

- [Spacelift docs — Migration from Administrative Flag](https://docs.spacelift.io/concepts/authorization/assigning-roles-stacks#migration-from-administrative-flag)
- [spacelift_role_attachment resource](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/role_attachment)
- [spacelift-io/terraform-provider-spacelift v1.37.0 release](https://github.com/spacelift-io/terraform-provider-spacelift/releases/tag/v1.37.0)